### PR TITLE
TRestTrackAnalysisProcess fix null pointer access

### DIFF
--- a/src/TRestTrackAnalysisProcess.cxx
+++ b/src/TRestTrackAnalysisProcess.cxx
@@ -933,11 +933,17 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
     SetObservableValue((string) "MaxTrackEnergyRatio", trackEnergyRatio);
 
     TRestHits hits;
-    TRestHits* hitsXZ = fInputTrackEvent->GetMaxEnergyTrack("X")->GetHits();
-    TRestHits* hitsYZ = fInputTrackEvent->GetMaxEnergyTrack("Y")->GetHits();
+    TRestHits *hitsXZ = nullptr;
+    TRestHits *hitsYZ = nullptr;
+    if (fInputTrackEvent->GetMaxEnergyTrack("X"))
+        hitsXZ = fInputTrackEvent->GetMaxEnergyTrack("X")->GetHits();
+    if (fInputTrackEvent->GetMaxEnergyTrack("Y"))
+        hitsYZ = fInputTrackEvent->GetMaxEnergyTrack("Y")->GetHits();
+
     auto hitsBoth = {hitsXZ, hitsYZ};
 
     for(auto arg : hitsBoth){
+        if (arg == nullptr) continue;
         for(int n = 0; n < arg->GetNumberOfHits(); n++){
             // your code in the existing loop, replacing `hits` by `arg`
             Double_t eDep = arg->GetEnergy(n);


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![8](https://badgen.net/badge/Size/8/orange) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/cris_trackObs/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/cris_trackObs) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Solved the issues with null pointers when calling GetHits in ```TRestTrackAnalysisProcess```