### PR TITLE
Fixing bug on inheritance of DrawEvent from base class

### DIFF
--- a/inc/TRestTrackEvent.h
+++ b/inc/TRestTrackEvent.h
@@ -85,7 +85,7 @@ class TRestTrackEvent : public TRestEvent {
     void SetLevels();
     Int_t GetLevels() { return fLevels; }
 
-    TPad* DrawEvent(TString option = "");
+    TPad* DrawEvent(const TString& option = "");
 
     TPad* GetPad() { return fPad; }
 

--- a/src/TRestTrackEvent.cxx
+++ b/src/TRestTrackEvent.cxx
@@ -357,7 +357,7 @@ void TRestTrackEvent::PrintEvent(Bool_t fullInfo) {
 }
 
 // Draw current event in a Tpad
-TPad* TRestTrackEvent::DrawEvent(TString option) {
+TPad* TRestTrackEvent::DrawEvent(const TString& option) {
     /* Not used for the moment
     Bool_t drawXZ = false;
     Bool_t drawYZ = false;


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![2](https://badgen.net/badge/Size/2/orange) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/DrawEventFix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/DrawEventFix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

After new changes in the code, it seems that `DrawEvent` is not working for some inherited classes from `TRestEvent`

This PR fix this bug by replacing:
```
- TPad* DrawEvent(TString option = "");
+ TPad* DrawEvent(const TString& option = "");
```