### PR TITLE
Renaming endl to RESTendl and other logger functions

### DIFF
--- a/inc/TRestTrackAnalysisProcess.h
+++ b/inc/TRestTrackAnalysisProcess.h
@@ -153,12 +153,12 @@ class TRestTrackAnalysisProcess : public TRestEventProcess {
 
         if (fCutsEnabled) {
             std::cout << "Number of tracks in X cut : ( " << fNTracksXCut.X() << " , " << fNTracksXCut.Y()
-                      << " ) " << endl;
+                      << " ) " << std::endl;
             std::cout << "Number of tracks in Y cut : ( " << fNTracksYCut.X() << " , " << fNTracksYCut.Y()
-                      << " ) " << endl;
+                      << " ) " << std::endl;
         } else {
-            std::cout << endl;
-            std::cout << "No cuts have been enabled" << endl;
+            std::cout << std::endl;
+            std::cout << "No cuts have been enabled" << std::endl;
         }
 
         EndPrintProcess();

--- a/inc/TRestTrackBlobAnalysisProcess.h
+++ b/inc/TRestTrackBlobAnalysisProcess.h
@@ -108,7 +108,7 @@ class TRestTrackBlobAnalysisProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " Hits to check factor : " << fHitsToCheckFraction << endl;
+        RESTMetadata << " Hits to check factor : " << fHitsToCheckFraction << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestTrackLinearizationProcess.h
+++ b/inc/TRestTrackLinearizationProcess.h
@@ -49,7 +49,7 @@ class TRestTrackLinearizationProcess : public TRestEventProcess {
 
     void PrintMetadata() override {
         BeginPrintProcess();
-        metadata << "Max nodes: " << fMaxNodes << endl;
+        RESTMetadata << "Max nodes: " << fMaxNodes << RESTendl;
         EndPrintProcess();
     }
 

--- a/inc/TRestTrackPathMinimizationProcess.h
+++ b/inc/TRestTrackPathMinimizationProcess.h
@@ -56,11 +56,11 @@ class TRestTrackPathMinimizationProcess : public TRestEventProcess {
         //           fMaxNodes << endl;
 
         if (fWeightHits)
-            metadata << "Weight hits : enabled" << endl;
+            RESTMetadata << "Weight hits : enabled" << RESTendl;
         else
-            metadata << "Weight hits : disabled" << endl;
+            RESTMetadata << "Weight hits : disabled" << RESTendl;
 
-        metadata << "Minimization method " << fMinMethod << endl;
+        RESTMetadata << "Minimization method " << fMinMethod << RESTendl;
         EndPrintProcess();
     }
 

--- a/inc/TRestTrackReconnectionProcess.h
+++ b/inc/TRestTrackReconnectionProcess.h
@@ -50,13 +50,13 @@ class TRestTrackReconnectionProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Split track : ";
+        RESTMetadata << "Split track : ";
         if (fSplitTrack)
-            metadata << " enabled" << endl;
+            RESTMetadata << " enabled" << RESTendl;
         else
-            metadata << " disabled" << endl;
+            RESTMetadata << " disabled" << RESTendl;
 
-        metadata << "Number of sigmas to defined a branch : " << fNSigmas << endl;
+        RESTMetadata << "Number of sigmas to defined a branch : " << fNSigmas << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestTrackReductionProcess.h
+++ b/inc/TRestTrackReductionProcess.h
@@ -45,12 +45,12 @@ class TRestTrackReductionProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " Starting distance : " << fStartingDistance << endl;
-        metadata << " Minimum distance : " << fMinimumDistance << endl;
-        metadata << " Distance step factor : " << fDistanceStepFactor << endl;
-        metadata << " Maximum number of nodes : " << fMaxNodes << endl;
-        metadata << " Perform kMeans clustering : " << fKmeans << endl;
-        if (fKmeans) metadata << " Maximum iterations : " << fMaxIt << endl;
+        RESTMetadata << " Starting distance : " << fStartingDistance << RESTendl;
+        RESTMetadata << " Minimum distance : " << fMinimumDistance << RESTendl;
+        RESTMetadata << " Distance step factor : " << fDistanceStepFactor << RESTendl;
+        RESTMetadata << " Maximum number of nodes : " << fMaxNodes << RESTendl;
+        RESTMetadata << " Perform kMeans clustering : " << fKmeans << RESTendl;
+        if (fKmeans) RESTMetadata << " Maximum iterations : " << fMaxIt << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestTrackViewerProcess.h
+++ b/inc/TRestTrackViewerProcess.h
@@ -63,7 +63,7 @@ class TRestTrackViewerProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Draw Origin End : " << fDrawOriginEnd << endl;
+        RESTMetadata << "Draw Origin End : " << fDrawOriginEnd << RESTendl;
 
         EndPrintProcess();
     }

--- a/src/TRestTrackAnalysisProcess.cxx
+++ b/src/TRestTrackAnalysisProcess.cxx
@@ -429,7 +429,7 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     for (int tck = 0; tck < fInputTrackEvent->GetNumberOfTracks(); tck++)
         fOutputTrackEvent->AddTrack(fInputTrackEvent->GetTrack(tck));
 
-    if (this->GetVerboseLevel() >= REST_Debug) fInputTrackEvent->PrintOnlyTracks();
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) fInputTrackEvent->PrintOnlyTracks();
 
     /* {{{ Number of tracks observables */
     Int_t nTracksX = 0, nTracksY = 0, nTracksXYZ = 0;
@@ -872,8 +872,8 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         tckMaxXYZ_SigmaX = fInputTrackEvent->GetMaxEnergyTrack()->GetHits()->GetSigmaX();
         tckMaxXYZ_SigmaY = fInputTrackEvent->GetMaxEnergyTrack()->GetHits()->GetSigmaY();
         tckMaxXYZ_SigmaZ = fInputTrackEvent->GetMaxEnergyTrack()->GetHits()->GetSigmaZ2();
-        debug << "id: " << fInputTrackEvent->GetID() << " " << fInputTrackEvent->GetSubEventTag()
-              << " tckMaxEnXYZ: " << tckMaxEnXYZ << endl;
+        RESTDebug << "id: " << fInputTrackEvent->GetID() << " " << fInputTrackEvent->GetSubEventTag()
+              << " tckMaxEnXYZ: " << tckMaxEnXYZ << RESTendl;
         tckMaxXYZ_gausSigmaX = fInputTrackEvent->GetMaxEnergyTrack()->GetHits()->GetGaussSigmaX();
         tckMaxXYZ_gausSigmaY = fInputTrackEvent->GetMaxEnergyTrack()->GetHits()->GetGaussSigmaY();
         tckMaxXYZ_gausSigmaZ = fInputTrackEvent->GetMaxEnergyTrack()->GetHits()->GetGaussSigmaZ();
@@ -892,8 +892,8 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         tckMaxXZ_SigmaZ = fInputTrackEvent->GetMaxEnergyTrack("X")->GetHits()->GetSigmaZ2();
         tckMaxXZ_gausSigmaX = fInputTrackEvent->GetMaxEnergyTrack("X")->GetHits()->GetGaussSigmaX();
         tckMaxXZ_gausSigmaZ_XZ = fInputTrackEvent->GetMaxEnergyTrack("X")->GetHits()->GetGaussSigmaZ();
-        debug << "id: " << fInputTrackEvent->GetID() << " " << fInputTrackEvent->GetSubEventTag()
-              << " tckMaxEnX: " << tckMaxEnX << endl;
+        RESTDebug << "id: " << fInputTrackEvent->GetID() << " " << fInputTrackEvent->GetSubEventTag()
+              << " tckMaxEnX: " << tckMaxEnX << RESTendl;
     }
 
     SetObservableValue((string) "MaxTrackEnergy_X", tckMaxEnX);
@@ -908,8 +908,8 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         tckMaxYZ_SigmaZ = fInputTrackEvent->GetMaxEnergyTrack("Y")->GetHits()->GetSigmaZ2();
         tckMaxYZ_gausSigmaY = fInputTrackEvent->GetMaxEnergyTrack("Y")->GetHits()->GetGaussSigmaY();
         tckMaxYZ_gausSigmaZ_YZ = fInputTrackEvent->GetMaxEnergyTrack("Y")->GetHits()->GetGaussSigmaZ();
-        debug << "id: " << fInputTrackEvent->GetID() << " " << fInputTrackEvent->GetSubEventTag()
-              << " tckMaxEnY: " << tckMaxEnY << endl;
+        RESTDebug << "id: " << fInputTrackEvent->GetID() << " " << fInputTrackEvent->GetSubEventTag()
+              << " tckMaxEnY: " << tckMaxEnY << RESTendl;
     }
 
     SetObservableValue((string) "MaxTrackEnergy_Y", tckMaxEnY);
@@ -1210,7 +1210,7 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         if (nTracksY < fNTracksYCut.X() || nTracksY > fNTracksYCut.Y()) return nullptr;
     }
 
-    if (GetVerboseLevel() >= REST_Extreme) GetChar();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
 
     return fOutputTrackEvent;
 }

--- a/src/TRestTrackDetachIsolatedNodesProcess.cxx
+++ b/src/TRestTrackDetachIsolatedNodesProcess.cxx
@@ -51,11 +51,11 @@ void TRestTrackDetachIsolatedNodesProcess::InitProcess() {}
 TRestEvent* TRestTrackDetachIsolatedNodesProcess::ProcessEvent(TRestEvent* inputEvent) {
     fInputTrackEvent = (TRestTrackEvent*)inputEvent;
 
-    if (this->GetVerboseLevel() >= REST_Debug)
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
         cout << "TRestTrackDetachIsolatedNodesProcess. Number of tracks : "
              << fInputTrackEvent->GetNumberOfTracks() << endl;
 
-    if (GetVerboseLevel() >= REST_Debug) fInputTrackEvent->PrintEvent();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) fInputTrackEvent->PrintEvent();
 
     // Copying the input tracks to the output track
     for (int tck = 0; tck < fInputTrackEvent->GetNumberOfTracks(); tck++)
@@ -72,7 +72,7 @@ TRestEvent* TRestTrackDetachIsolatedNodesProcess::ProcessEvent(TRestEvent* input
 
         /* {{{ Debug output */
 
-        if (this->GetVerboseLevel() >= REST_Debug) {
+        if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             Int_t pId = fInputTrackEvent->GetTrack(tck)->GetParentID();
             cout << "Track : " << tck << " TrackID : " << tckId << " ParentID : " << pId << endl;
             cout << "-----------------" << endl;
@@ -108,7 +108,7 @@ TRestEvent* TRestTrackDetachIsolatedNodesProcess::ProcessEvent(TRestEvent* input
                 hitConnectivity += originHits->GetEnergyInCylinder(pos0, pos1, fTubeRadius);
             }
 
-            if (GetVerboseLevel() >= REST_Debug)
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
                 cout << "Hit : " << n << " Connectivity : " << hitConnectivity
                      << " distance : " << distance / 2. << endl;
 
@@ -145,7 +145,7 @@ TRestEvent* TRestTrackDetachIsolatedNodesProcess::ProcessEvent(TRestEvent* input
         fOutputTrackEvent->AddTrack(&connectedTrack);
     }
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "xxxx DetachIsolatedNodes trackEvent output xxxxx" << endl;
         fOutputTrackEvent->PrintEvent();
         cout << "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" << endl;

--- a/src/TRestTrackLineAnalysisProcess.cxx
+++ b/src/TRestTrackLineAnalysisProcess.cxx
@@ -144,8 +144,8 @@ TRestEvent* TRestTrackLineAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) 
         // Retreive origin and end of the track for the XZ projection
         fTrackEvent->GetMaxTrackBoundaries(orig, end);
 
-        debug << "Origin: " << orig.X() << " y: " << orig.Y() << " z: " << orig.Z() << endl;
-        debug << "End : " << end.X() << " y: " << end.Y() << " z: " << end.Z() << endl;
+        RESTDebug << "Origin: " << orig.X() << " y: " << orig.Y() << " z: " << orig.Z() << RESTendl;
+        RESTDebug << "End : " << end.X() << " y: " << end.Y() << " z: " << end.Z() << RESTendl;
 
         // Compute some observables
         double dX = (orig.X() - end.X());
@@ -155,7 +155,7 @@ TRestEvent* TRestTrackLineAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) 
         angle = TMath::ACos(dZ / length);
         downwards = dZ > 0;
 
-        debug << "Track length " << length << " angle: " << angle << endl;
+        RESTDebug << "Track length " << length << " angle: " << angle << RESTendl;
 
         trackEnergyX = tckX->GetEnergy();
         trackEnergyY = tckY->GetEnergy();

--- a/src/TRestTrackLinearizationProcess.cxx
+++ b/src/TRestTrackLinearizationProcess.cxx
@@ -112,20 +112,20 @@ TRestEvent* TRestTrackLinearizationProcess::ProcessEvent(TRestEvent* inputEvent)
         GetHitsProjection(hits, fMaxNodes, vHits);
         if (vHits.GetNumberOfHits() == 0) continue;
 
-        debug << "Adding track " << endl;
+        RESTDebug << "Adding track " << RESTendl;
         // Store tracks after tinearization
         TRestTrack newTrack;
         newTrack.SetTrackID(fOutTrackEvent->GetNumberOfTracks() + 1);
         newTrack.SetParentID(track->GetTrackID());
         newTrack.SetVolumeHits(vHits);
 
-        debug << "Is XZ " << newTrack.isXZ() << " Is YZ " << newTrack.isYZ() << endl;
+        RESTDebug << "Is XZ " << newTrack.isXZ() << " Is YZ " << newTrack.isYZ() << RESTendl;
 
         fOutTrackEvent->AddTrack(&newTrack);
     }
 
-    debug << "NTracks  X " << fOutTrackEvent->GetNumberOfTracks("X") << " Y "
-          << fOutTrackEvent->GetNumberOfTracks("Y") << " " << fOutTrackEvent->GetNumberOfTracks("X") << endl;
+    RESTDebug << "NTracks  X " << fOutTrackEvent->GetNumberOfTracks("X") << " Y "
+          << fOutTrackEvent->GetNumberOfTracks("Y") << " " << fOutTrackEvent->GetNumberOfTracks("X") << RESTendl;
 
     fOutTrackEvent->SetLevels();
     return fOutTrackEvent;
@@ -143,7 +143,7 @@ void TRestTrackLinearizationProcess::GetHitsProjection(TRestVolumeHits* hits, co
     const REST_HitType hType = hits->GetType(0);
     vHits.RemoveHits();
 
-    debug << "NHits " << nHits << " hits Type " << hType << endl;
+    RESTDebug << "NHits " << nHits << " hits Type " << hType << RESTendl;
 
     if (hType == XZ) {
         auto cl = GetBestNodes(hits->fX, hits->fZ, hits->fEnergy, nodes);
@@ -161,16 +161,16 @@ void TRestTrackLinearizationProcess::GetHitsProjection(TRestVolumeHits* hits, co
             vHits.AddHit(xy, z, hits->GetZ(0), 0, 0, hType, 0, 0, 0);
         }
     } else {
-        warning << "Track linearization not implemented for XYZ tracks" << endl;
+        RESTWarning << "Track linearization not implemented for XYZ tracks" << RESTendl;
         return;
     }
 
     TRestVolumeHits::kMeansClustering(hits, vHits, 1);
 
-    if (GetVerboseLevel() >= REST_Debug)
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
         for (int i = 0; i < vHits.GetNumberOfHits(); i++)
-            debug << i << " " << vHits.GetX(i) << " " << vHits.GetY(i) << " " << vHits.GetZ(i) << " "
-                  << vHits.GetType(i) << endl;
+            RESTDebug << i << " " << vHits.GetX(i) << " " << vHits.GetY(i) << " " << vHits.GetZ(i) << " "
+                  << vHits.GetType(i) << RESTendl;
 }
 
 ///////////////////////////////////////////////
@@ -192,8 +192,8 @@ std::vector<std::pair<double, double>> TRestTrackLinearizationProcess::GetBestNo
     double totEn = 0;
     for (const auto& en : fEn) totEn += en;
 
-    debug << "Max " << max[0] << " " << max[1] << endl;
-    debug << "Min " << min[0] << " " << min[1] << endl;
+    RESTDebug << "Max " << max[0] << " " << max[1] << RESTendl;
+    RESTDebug << "Min " << min[0] << " " << min[1] << RESTendl;
 
     TGraph gr[2];
 
@@ -208,7 +208,7 @@ std::vector<std::pair<double, double>> TRestTrackLinearizationProcess::GetBestNo
         }
     }
 
-    debug << "Points graph " << c << " Hits " << nHits << endl;
+    RESTDebug << "Points graph " << c << " Hits " << nHits << RESTendl;
 
     int bestIndex = 0;
     double bestFit;
@@ -216,7 +216,7 @@ std::vector<std::pair<double, double>> TRestTrackLinearizationProcess::GetBestNo
     double intercept;
 
     std::string fitOpt = "";
-    if (GetVerboseLevel() < REST_Debug) fitOpt = "Q";
+    if (GetVerboseLevel() < TRestStringOutput::REST_Verbose_Level::REST_Debug) fitOpt = "Q";
 
     for (int l = 0; l < 2; l++) {
         TF1 f1("f1", "[0] * x + [1]", min[l], max[l]);
@@ -236,8 +236,8 @@ std::vector<std::pair<double, double>> TRestTrackLinearizationProcess::GetBestNo
         }
     }
 
-    debug << "Best fit " << bestFit << " " << bestIndex << endl;
-    debug << "Slope " << slope << " Intercept " << intercept << endl;
+    RESTDebug << "Best fit " << bestFit << " " << bestIndex << RESTendl;
+    RESTDebug << "Slope " << slope << " Intercept " << intercept << RESTendl;
 
     std::vector<std::pair<double, double>> cluster(nodes);
     for (int i = 0; i < nodes; i++) {

--- a/src/TRestTrackPathMinimizationProcess.cxx
+++ b/src/TRestTrackPathMinimizationProcess.cxx
@@ -31,7 +31,7 @@ void TRestTrackPathMinimizationProcess::InitProcess() {}
 TRestEvent* TRestTrackPathMinimizationProcess::ProcessEvent(TRestEvent* inputEvent) {
     fInputTrackEvent = (TRestTrackEvent*)inputEvent;
 
-    if (this->GetVerboseLevel() >= REST_Debug)
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
         cout << "TRestTrackPathMinimizationProcess. Number of tracks : "
              << fInputTrackEvent->GetNumberOfTracks() << endl;
 
@@ -47,7 +47,7 @@ TRestEvent* TRestTrackPathMinimizationProcess::ProcessEvent(TRestEvent* inputEve
         const int nHits = hits->GetNumberOfHits();
 
         /* {{{ Debug output */
-        if (this->GetVerboseLevel() >= REST_Debug) {
+        if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             Int_t pId = fInputTrackEvent->GetTrack(tck)->GetParentID();
             cout << "Track : " << tck << " TrackID : " << tckId << " ParentID : " << pId << endl;
             cout << "-----------------" << endl;
@@ -56,7 +56,7 @@ TRestEvent* TRestTrackPathMinimizationProcess::ProcessEvent(TRestEvent* inputEve
         }
         /* }}} */
 
-        debug << "hits : " << nHits << endl;
+        RESTDebug << "hits : " << nHits << RESTendl;
 
         std::vector<int> bestPath(nHits);
         for (int i = 0; i < nHits; i++) bestPath[i] = i;  // Initialize
@@ -91,7 +91,7 @@ TRestEvent* TRestTrackPathMinimizationProcess::ProcessEvent(TRestEvent* inputEve
 void TRestTrackPathMinimizationProcess::NearestNeighbour(TRestVolumeHits* hits, std::vector<int>& bestPath) {
     const int nHits = hits->GetNumberOfHits();
     double dist[nHits][nHits];
-    debug << "Nhits " << nHits << endl;
+    RESTDebug << "Nhits " << nHits << RESTendl;
 
     if (nHits < 3) return;
 
@@ -152,7 +152,7 @@ void TRestTrackPathMinimizationProcess::NearestNeighbour(TRestVolumeHits* hits, 
         }
     }
 
-    if (this->GetVerboseLevel() >= REST_Debug) {
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "Min path ";
         for (const auto& v : bestPath) cout << v << " ";
         cout << " " << min_path << endl;
@@ -167,7 +167,7 @@ void TRestTrackPathMinimizationProcess::NearestNeighbour(TRestVolumeHits* hits, 
 void TRestTrackPathMinimizationProcess::BruteForce(TRestVolumeHits* hits, std::vector<int>& bestPath) {
     const int nHits = hits->GetNumberOfHits();
     double dist[nHits][nHits];
-    debug << "Nhits " << nHits << endl;
+    RESTDebug << "Nhits " << nHits << RESTendl;
 
     if (nHits < 3) return;
 
@@ -182,7 +182,7 @@ void TRestTrackPathMinimizationProcess::BruteForce(TRestVolumeHits* hits, std::v
         }
     }
 
-    if (this->GetVerboseLevel() >= REST_Debug) {
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         for (int i = 0; i < nHits; i++) {
             for (int j = 0; j < nHits; j++) {
                 cout << dist[i][j] << " ";
@@ -230,7 +230,7 @@ void TRestTrackPathMinimizationProcess::BruteForce(TRestVolumeHits* hits, std::v
         } while (std::next_permutation(vertex.begin(), vertex.end()));
     }
 
-    if (this->GetVerboseLevel() >= REST_Debug) {
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "Min path ";
         for (const auto& v : bestPath) cout << v << " ";
         cout << " " << min_path << endl;
@@ -325,7 +325,7 @@ void TRestTrackPathMinimizationProcess::HeldKarp(TRestVolumeHits* hits, std::vec
         GetChar();
     */
 
-    if (GetVerboseLevel() >= REST_Extreme) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
         for (int n = 0; n < segment_count; n++) cout << "n : " << n << " elen : " << elen[n] << endl;
         GetChar();
     }
@@ -358,10 +358,10 @@ void TRestTrackPathMinimizationProcess::HeldKarp(TRestVolumeHits* hits, std::vec
     free(elen);
     // free( enBetween );
 
-    if (GetVerboseLevel() >= REST_Extreme) GetChar();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
 
     if (rval != 0) {
-        if (GetVerboseLevel() >= REST_Warning) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning) {
             cout << "REST WARNING. TRestTrackPathMinimizationProcess. HELDKARP FAILED." << endl;
         }
         fOutputTrackEvent->SetOK(false);

--- a/src/TRestTrackReconnectionProcess.cxx
+++ b/src/TRestTrackReconnectionProcess.cxx
@@ -65,7 +65,7 @@ TRestEvent* TRestTrackReconnectionProcess::ProcessEvent(TRestEvent* inputEvent) 
         TRestVolumeHits* hits = fInputTrackEvent->GetTrack(tck)->GetVolumeHits();
 
         /* {{{ Debug output */
-        if (this->GetVerboseLevel() >= REST_Debug) {
+        if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << "TRestTrackReconnectionProcess. Input hits" << endl;
             Int_t pId = fInputTrackEvent->GetTrack(tck)->GetParentID();
             cout << "Track : " << tck << " TrackID : " << tckId << " ParentID : " << pId << endl;
@@ -94,10 +94,10 @@ TRestEvent* TRestTrackReconnectionProcess::ProcessEvent(TRestEvent* inputEvent) 
             SetDistanceMeanAndSigma(&resultHits);
             tBranches = GetTrackBranches(resultHits, fNSigmas);
 
-            if (GetVerboseLevel() >= REST_Debug) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << "Break and reconnect finished" << endl;
                 cout << "Branches : " << tBranches << endl;
-                if (GetVerboseLevel() >= REST_Extreme) GetChar();
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
             }
 
             initialHits = resultHits;
@@ -125,10 +125,10 @@ TRestEvent* TRestTrackReconnectionProcess::ProcessEvent(TRestEvent* inputEvent) 
         if (fSplitTrack) {
             BreakTracks(&initialHits, subHitSets, fNSigmas);
 
-            if (GetVerboseLevel() >= REST_Debug) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << " **** Splitting track : " << endl;
                 cout << "Number of subHitSets : " << subHitSets.size() << endl;
-                if (GetVerboseLevel() >= REST_Extreme) GetChar();
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
             }
         }
 
@@ -148,11 +148,11 @@ TRestEvent* TRestTrackReconnectionProcess::ProcessEvent(TRestEvent* inputEvent) 
     SetObservableValue("branches", trackBranches);
     // cout << "Track branches : " << trackBranches << endl;
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "++++++++++++++++++++++++++++++++" << endl;
         fOutputTrackEvent->PrintEvent();
         cout << "++++++++++++++++++++++++++++++++" << endl;
-        if (GetVerboseLevel() >= REST_Extreme) GetChar();
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
     }
 
     return fOutputTrackEvent;
@@ -164,7 +164,7 @@ TRestEvent* TRestTrackReconnectionProcess::ProcessEvent(TRestEvent* inputEvent) 
 void TRestTrackReconnectionProcess::BreakTracks(TRestVolumeHits* hits, vector<TRestVolumeHits>& hitSets,
                                                 Double_t nSigma) {
     hitSets.clear();
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" << endl;
         cout << "BreakTracks. Breaking tracks into hits subsets." << endl;
     }
@@ -179,7 +179,7 @@ void TRestTrackReconnectionProcess::BreakTracks(TRestVolumeHits* hits, vector<TR
         Double_t sZ = hits->GetSigmaZ(n);
         Double_t energy = hits->GetEnergy(n);
 
-        if (GetVerboseLevel() >= REST_Debug && n > 0) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug && n > 0) {
             cout << "Distance : " << hits->GetDistance(n - 1, n);
             if (hits->GetDistance(n - 1, n) > fMeanDistance + nSigma * fSigma) cout << " BREAKKKK";
             cout << endl;
@@ -192,17 +192,17 @@ void TRestTrackReconnectionProcess::BreakTracks(TRestVolumeHits* hits, vector<TR
 
         subHits.AddHit(x, y, z, energy, 0, hits->GetType(n), sX, sY, sZ);
 
-        if (GetVerboseLevel() >= REST_Debug)
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
             cout << "H : " << n << " X : " << x << " Y : " << y << " Z : " << z << endl;
     }
 
     hitSets.push_back(subHits);
 
-    if (GetVerboseLevel() >= REST_Debug) cout << "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" << endl;
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) cout << "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" << endl;
 }
 
 void TRestTrackReconnectionProcess::ReconnectTracks(vector<TRestVolumeHits>& hitSets) {
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" << endl;
         cout << "ReconnectTracks. Connecting back sub tracks " << endl;
     }
@@ -218,7 +218,7 @@ void TRestTrackReconnectionProcess::ReconnectTracks(vector<TRestVolumeHits>& hit
     Int_t nHits[nSubTracks];
     for (int i = 0; i < nSubTracks; i++) nHits[i] = hitSets[i].GetNumberOfHits();
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "ORIGINAL" << endl;
         cout << "--------" << endl;
         for (int i = 0; i < nSubTracks; i++) {
@@ -346,7 +346,7 @@ void TRestTrackReconnectionProcess::ReconnectTracks(vector<TRestVolumeHits>& hit
 
     nSubTracks = hitSets.size();
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "New subtracks : " << nSubTracks << endl;
 
         cout << "AFTER REMOVAL" << endl;
@@ -358,12 +358,12 @@ void TRestTrackReconnectionProcess::ReconnectTracks(vector<TRestVolumeHits>& hit
             hitSets[i].PrintHits();
         }
         cout << "--------" << endl;
-        if (GetVerboseLevel() >= REST_Extreme) GetChar();
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
     }
 
     if (nSubTracks > 1) ReconnectTracks(hitSets);
 
-    if (GetVerboseLevel() >= REST_Debug) cout << "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" << endl;
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) cout << "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" << endl;
 }
 
 Int_t TRestTrackReconnectionProcess::GetTrackBranches(TRestHits& h, Double_t nSigma) {
@@ -395,7 +395,7 @@ void TRestTrackReconnectionProcess::SetDistanceMeanAndSigma(TRestHits* h) {
 
     fSigma = TMath::Sqrt(fMeanDistance);
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "-----> Node distance average ; " << fMeanDistance << endl;
         cout << "-----> Node distance sigma : " << fSigma << endl;
         cout << endl;

--- a/src/TRestTrackReductionProcess.cxx
+++ b/src/TRestTrackReductionProcess.cxx
@@ -36,7 +36,7 @@ TRestEvent* TRestTrackReductionProcess::ProcessEvent(TRestEvent* inputEvent) {
     for (int tck = 0; tck < fInputTrackEvent->GetNumberOfTracks(); tck++)
         fOutputTrackEvent->AddTrack(fInputTrackEvent->GetTrack(tck));
 
-    if (this->GetVerboseLevel() >= REST_Debug) fInputTrackEvent->PrintOnlyTracks();
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) fInputTrackEvent->PrintOnlyTracks();
 
     // Reducing the hits inside each track
     for (int tck = 0; tck < fInputTrackEvent->GetNumberOfTracks(); tck++) {
@@ -45,7 +45,7 @@ TRestEvent* TRestTrackReductionProcess::ProcessEvent(TRestEvent* inputEvent) {
         TRestTrack* track = fInputTrackEvent->GetTrack(tck);
         TRestVolumeHits* hits = track->GetVolumeHits();
 
-        if (this->GetVerboseLevel() >= REST_Debug)
+        if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
             cout << "TRestTrackReductionProcess. Reducing hits in track id : " << track->GetTrackID() << endl;
 
         TRestVolumeHits vHits = (TRestVolumeHits)(*hits);
@@ -75,7 +75,7 @@ TRestEvent* TRestTrackReductionProcess::ProcessEvent(TRestEvent* inputEvent) {
 void TRestTrackReductionProcess::getHitsMerged(TRestVolumeHits& hits) {
     Double_t distance = fStartingDistance;
     while (distance < fMinimumDistance || hits.GetNumberOfHits() > fMaxNodes) {
-        if (this->GetVerboseLevel() >= REST_Debug) {
+        if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << "TRestTrackReductionProcess. Merging track hits within a "
                  << "distance : " << distance << " mm" << endl;
             cout << "TRestTrackReductionProcess. Hits now : " << hits.GetNumberOfHits() << endl;
@@ -97,7 +97,7 @@ void TRestTrackReductionProcess::getHitsMerged(TRestVolumeHits& hits) {
             }
         }
 
-        debug << "TRestTrackReductionProcess. Number of hits merged : " << mergedHits << endl;
+        RESTDebug << "TRestTrackReductionProcess. Number of hits merged : " << mergedHits << RESTendl;
         mergedHits = 0;
 
         distance *= fDistanceStepFactor;


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 83](https://badgen.net/badge/PR%20Size/Ok%3A%2083/green) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/RESTendl) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/RESTendl)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related with https://github.com/rest-for-physics/framework/pull/225:
- Renamed custom `endl` to `RESTendl`
- Renamed other logger functions
  - `info` --> `RESTInfo`  
  - `debug` --> `RESTDebug`
  - `essential` --> `RESTEssential`
  - `warning` --> `RESTWarning`
  - `fout` --> `RESTcout`
  - `ferr` --> `RESTError`