### PR TITLE
replaced dynamic length array initializaion

### DIFF
--- a/inc/TRestTrackPathMinimizationProcess.h
+++ b/inc/TRestTrackPathMinimizationProcess.h
@@ -13,14 +13,8 @@
 #define RestCore_TRestTrackPathMinimizationProcess
 
 #include <TRestTrackEvent.h>
-
 #include "TRestEventProcess.h"
-
-#ifndef __CINT__
-#ifndef WIN32
 #include <trackMinimization.h>
-#endif
-#endif
 
 class TRestTrackPathMinimizationProcess : public TRestEventProcess {
    private:

--- a/src/TRestTrackPathMinimizationProcess.cxx
+++ b/src/TRestTrackPathMinimizationProcess.cxx
@@ -90,7 +90,7 @@ TRestEvent* TRestTrackPathMinimizationProcess::ProcessEvent(TRestEvent* inputEve
 ///
 void TRestTrackPathMinimizationProcess::NearestNeighbour(TRestVolumeHits* hits, std::vector<int>& bestPath) {
     const int nHits = hits->GetNumberOfHits();
-    double dist[nHits][nHits];
+    vector<vector<double>> dist(nHits,vector<double>(nHits));
     RESTDebug << "Nhits " << nHits << RESTendl;
 
     if (nHits < 3) return;
@@ -166,7 +166,7 @@ void TRestTrackPathMinimizationProcess::NearestNeighbour(TRestVolumeHits* hits, 
 ///
 void TRestTrackPathMinimizationProcess::BruteForce(TRestVolumeHits* hits, std::vector<int>& bestPath) {
     const int nHits = hits->GetNumberOfHits();
-    double dist[nHits][nHits];
+    vector<vector<double>> dist(nHits, vector<double>(nHits));
     RESTDebug << "Nhits " << nHits << RESTendl;
 
     if (nHits < 3) return;
@@ -260,7 +260,7 @@ void TRestTrackPathMinimizationProcess::HeldKarp(TRestVolumeHits* hits, std::vec
     */
 
     int k = 0;
-    int bestP[nHits];
+    vector<int> bestP(nHits);
     Int_t rval = 0;
     for (int i = 0; i < nHits; i++) {
         bestP[i] = i;
@@ -330,7 +330,7 @@ void TRestTrackPathMinimizationProcess::HeldKarp(TRestVolumeHits* hits, std::vec
         GetChar();
     }
 
-    rval = TrackMinimization_segment(nHits, elen, bestP);
+    rval = TrackMinimization_segment(nHits, elen, &bestP[0]);
 
     /**** Just Printing
     for( int i = 0; i < hits->GetNumberOfHits()-1; i++ )

--- a/src/TRestTrackReconnectionProcess.cxx
+++ b/src/TRestTrackReconnectionProcess.cxx
@@ -215,7 +215,7 @@ void TRestTrackReconnectionProcess::ReconnectTracks(vector<TRestVolumeHits>& hit
 
     Int_t tracks[2][2];
 
-    Int_t nHits[nSubTracks];
+    vector<Int_t> nHits(nSubTracks);
     for (int i = 0; i < nSubTracks; i++) nHits[i] = hitSets[i].GetNumberOfHits();
 
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {

--- a/tsp/inc/config.h
+++ b/tsp/inc/config.h
@@ -150,3 +150,12 @@
 /* Define if unistd.h uses __vfork but does not prototype it */
 /* This happens under Irix 6 */
 /* #undef CC_PROTO___VFORK */
+#ifdef WIN32
+#undef HAVE_UNISTD_H
+#undef HAVE_SYS_RESOURCE_H
+#undef HAVE_SYS_SOCKET_H
+#undef HAVE_NETDB_H
+#undef HAVE_NETINET_IN_H
+#undef HAVE_SYS_TIME_H
+#undef TIME_WITH_SYS_TIME
+#endif  // WIN32


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![Ok: 14](https://badgen.net/badge/PR%20Size/Ok%3A%2014/green) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/windows-compile/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/windows-compile) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/windows-compile/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/windows-compile)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related to https://github.com/rest-for-physics/framework/pull/231. Array initialization with dynamic length is not available for msvc. Changed to vector. e.g. `Double_t x[nHits];` --> `vector<Double_t> x(nHits);`