### PR TITLE
New observables for Z sigma balance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-set( LibraryVersion "1.3" )
+set( LibraryVersion "1.4" )
 add_definitions(-DLIBRARY_VERSION="${LibraryVersion}")
 
 file(GLOB_RECURSE addon_src

--- a/src/TRestTrackAnalysisProcess.cxx
+++ b/src/TRestTrackAnalysisProcess.cxx
@@ -31,11 +31,12 @@
 /// * **nTracks_Y**: Number of tracks in the event with hits' coordinates only in Y and Z (not X).
 /// * **nTracks_XYZ**: Number of tracks in the event with hits' coordinates in X, Y and Z.
 ///
-/// Max track energies and track energy ratio:
+/// Max track energies, energy balance and track energy ratio:
 ///
 /// * **MaxTrackEnergy**: Energy of the most energetic track in the event with X, Y, Z coordinates.
 /// * **MaxTrackEnergy_X**: Energy of the most energetic track in the event with X, Z coordinates.
 /// * **MaxTrackEnergy_Y**: Energy of the most energetic track in the event with Y, Z coordinates.
+/// * **MaxTrackEnergyBalanceXY**: (tckMaxEnX - tckMaxEnY) / (tckMaxEnX + tckMaxEnY).
 /// * **MaxTrackEnergyRatio**: (totalEnergy - tckMaxEnergy) / totalEnergy
 /// with tckMaxEnergy = tckMaxEnX + tckMaxEnY + tckMaxEnXYZ.
 ///
@@ -47,6 +48,8 @@
 /// coordinates.
 /// * **SecondMaxTrackEnergy_Y**: Energy of the second most energetic track in the event with Y,Z
 /// coordinates.
+/// * **SecondMaxTrackEnergyBalanceXY**: (SecondTckMaxEnX - SecondTckMaxEnY) / (SecondTckMaxEnX +
+/// SecondTckMaxEnY).
 ///
 /// Track Length observables:
 ///
@@ -127,13 +130,14 @@
 /// * **MaxTrackSigmaZ**: The cluster size in Z of the main most energetic track.
 /// * **MaxTrack_XZ_SigmaX**: The cluster size in X of the main most energetic track in XZ projection.
 /// * **MaxTrack_YZ_SigmaY**: The cluster size in Y of the main most energetic track in YZ projection.
-/// * **MaxTrackZSigmaBalance**: (sigmaZ_XZ - sigmaZ_YZ) /(sigmaZ_XZ + sigmaZ_YZ).
 /// * **MaxTrackxySigmaBalance**: (sigmaX - sigmaY) /(sigmaX + sigmaY).
+/// * **MaxTrackZSigmaBalance**: (sigmaZ_XZ - sigmaZ_YZ) /(sigmaZ_XZ + sigmaZ_YZ).
 /// * **SecondMaxTrackSigmaX**: The cluster size in X of the second most energetic track.
 /// * **SecondMaxTrackSigmaY**: The cluster size in Y of the second most energetic track.
 /// * **SecondMaxTrack_XZ_SigmaX**: The cluster size in X of the second most energetic track in XZ projection.
 /// * **SecondMaxTrack_YZ_SigmaY**: The cluster size in Y of the second most energetic track in YZ projection.
-
+/// * **SecondMaxTrackxySigmaBalance**: (sigmaX - sigmaY) /(sigmaX + sigmaY).
+/// * **SecondMaxTrackZSigmaBalance**: (sigmaZ_XZ - sigmaZ_YZ) /(sigmaZ_XZ + sigmaZ_YZ).
 ///
 /// The gaussian sigma parameter measures the cluster size obtained from the fit to a gaussian of a given
 /// track hits.
@@ -157,6 +161,7 @@
 /// projection.
 /// * **SecondMaxTrackxySigmaGausBalance**:
 /// (secondGausSigma_x-secondGausSigma_y)/(secondGausSigma_x+secondGausSigma_y).
+/// * **SecondMaxTrackZSigmaGausBalance**: (gausSigmaZ_XZ - gausSigmaZ_YZ) /(gausSigmaZ_XZ + gausSigmaZ_YZ).
 ///
 /// Time observables:
 ///

--- a/src/TRestTrackAnalysisProcess.cxx
+++ b/src/TRestTrackAnalysisProcess.cxx
@@ -923,8 +923,8 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue((string) "MaxTrack_YZ_GaussSigmaY", tckMaxYZ_gausSigmaY);
     SetObservableValue((string) "MaxTrack_YZ_GaussSigmaZ", tckMaxYZ_gausSigmaZ_YZ);
 
-    SetObservableValue("MaxTrackxySigmaGausBalance", (tckMaxXZ_gausSigmaX - tckMaxXZ_gausSigmaX) /
-                                                         (tckMaxYZ_gausSigmaY + tckMaxYZ_gausSigmaY));
+    SetObservableValue("MaxTrackxySigmaGausBalance", (tckMaxXZ_gausSigmaX - tckMaxYZ_gausSigmaY) /
+                                                         (tckMaxXZ_gausSigmaX + tckMaxYZ_gausSigmaY));
     SetObservableValue("MaxTrackxySigmaBalance",
                        (tckMaxXZ_SigmaX - tckMaxYZ_SigmaY) / (tckMaxXZ_SigmaX + tckMaxYZ_SigmaY));
 
@@ -1043,17 +1043,16 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue((string) "SecondMaxTrack_YZ_GaussSigmaZ", tckSecondMaxYZ_gausSigmaZ_YZ);
 
     SetObservableValue("SecondMaxTrackxySigmaGausBalance",
-                       (tckSecondMaxXZ_gausSigmaX - tckSecondMaxXZ_gausSigmaX) /
-                           (tckSecondMaxYZ_gausSigmaY + tckSecondMaxYZ_gausSigmaY));
-    SetObservableValue("SecondMaxTrackxy2SigmaBalance", (tckSecondMaxXZ_SigmaZ - tckSecondMaxYZ_SigmaZ) /
-                                                            (tckSecondMaxXZ_SigmaZ + tckSecondMaxYZ_SigmaZ));
-
+                       (tckSecondMaxXZ_gausSigmaX - tckSecondMaxYZ_gausSigmaY) /
+                           (tckSecondMaxXZ_gausSigmaX + tckSecondMaxYZ_gausSigmaY));
+    SetObservableValue("SecondMaxTrackxySigmaBalance", (tckSecondMaxXZ_SigmaX - tckSecondMaxYZ_SigmaY) /
+                                                           (tckSecondMaxXZ_SigmaX + tckSecondMaxYZ_SigmaY));
+    SetObservableValue("SecondMaxTrackZSigmaBalance", (tckSecondMaxXZ_SigmaZ - tckSecondMaxYZ_SigmaZ) /
+                                                          (tckSecondMaxXZ_SigmaZ + tckSecondMaxYZ_SigmaZ));
     SetObservableValue("SecondMaxTrackZSigmaGausBalance",
                        (tckSecondMaxXZ_gausSigmaZ_XZ - tckSecondMaxYZ_gausSigmaZ_YZ) /
                            (tckSecondMaxXZ_gausSigmaZ_XZ + tckSecondMaxYZ_gausSigmaZ_YZ));
 
-    SetObservableValue("SecondMaxTrackZSigmaBalance",
-                       (tckMaxXZ_SigmaZ - tckMaxYZ_SigmaZ) / (tckMaxXZ_SigmaZ + tckMaxYZ_SigmaZ));
     /* }}} */
 
     /* {{{ Track Length observables (MaxTrackLength_XX) */

--- a/src/TRestTrackAnalysisProcess.cxx
+++ b/src/TRestTrackAnalysisProcess.cxx
@@ -943,6 +943,8 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("MaxTrackZSigmaBalance",
                        (tckMaxXZ_SigmaZ - tckMaxYZ_SigmaZ) / (tckMaxXZ_SigmaZ + tckMaxYZ_SigmaZ));
 
+    SetObservableValue("MaxTrackEnergyBalanceXY", (tckMaxEnX - tckMaxEnY) / (tckMaxEnX + tckMaxEnY));
+
     TRestHits hits;
     TRestHits* hitsXZ = nullptr;
     TRestHits* hitsYZ = nullptr;
@@ -1052,6 +1054,8 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("SecondMaxTrackZSigmaGausBalance",
                        (tckSecondMaxXZ_gausSigmaZ_XZ - tckSecondMaxYZ_gausSigmaZ_YZ) /
                            (tckSecondMaxXZ_gausSigmaZ_XZ + tckSecondMaxYZ_gausSigmaZ_YZ));
+    SetObservableValue("SecondMaxTrackEnergyBalanceXY", (tckSecondMaxEnergy_X - tckSecondMaxEnergy_Y) /
+                                                            (tckSecondMaxEnergy_X + tckSecondMaxEnergy_Y));
 
     /* }}} */
 

--- a/src/TRestTrackAnalysisProcess.cxx
+++ b/src/TRestTrackAnalysisProcess.cxx
@@ -923,8 +923,8 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue((string) "MaxTrack_YZ_GaussSigmaY", tckMaxYZ_gausSigmaY);
     SetObservableValue((string) "MaxTrack_YZ_GaussSigmaZ", tckMaxYZ_gausSigmaZ_YZ);
 
-    SetObservableValue("MaxTrackxySigmaGausBalance", (tckMaxXZ_gausSigmaX * tckMaxXZ_gausSigmaX) +
-                                                         (tckMaxYZ_gausSigmaY * tckMaxYZ_gausSigmaY));
+    SetObservableValue("MaxTrackxySigmaGausBalance", (tckMaxXZ_gausSigmaX - tckMaxXZ_gausSigmaX) /
+                                                         (tckMaxYZ_gausSigmaY + tckMaxYZ_gausSigmaY));
     SetObservableValue("MaxTrackxySigmaBalance",
                        (tckMaxXZ_SigmaX - tckMaxYZ_SigmaY) / (tckMaxXZ_SigmaX + tckMaxYZ_SigmaY));
 
@@ -1043,8 +1043,8 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue((string) "SecondMaxTrack_YZ_GaussSigmaZ", tckSecondMaxYZ_gausSigmaZ_YZ);
 
     SetObservableValue("SecondMaxTrackxySigmaGausBalance",
-                       (tckSecondMaxXZ_gausSigmaX * tckSecondMaxXZ_gausSigmaX) +
-                           (tckSecondMaxYZ_gausSigmaY * tckSecondMaxYZ_gausSigmaY));
+                       (tckSecondMaxXZ_gausSigmaX - tckSecondMaxXZ_gausSigmaX) /
+                           (tckSecondMaxYZ_gausSigmaY + tckSecondMaxYZ_gausSigmaY));
     SetObservableValue("SecondMaxTrackxy2SigmaBalance", (tckSecondMaxXZ_SigmaZ - tckSecondMaxYZ_SigmaZ) /
                                                             (tckSecondMaxXZ_SigmaZ + tckSecondMaxYZ_SigmaZ));
 

--- a/src/TRestTrackAnalysisProcess.cxx
+++ b/src/TRestTrackAnalysisProcess.cxx
@@ -145,7 +145,7 @@
 /// * **MaxTrack_XZ_GaussSigmaZ**: The cluster size in Z of the main most energetic track in XZ projection.
 /// * **MaxTrack_YZ_GaussSigmaY**: The cluster size in Y of the main most energetic track in YZ projection.
 /// * **MaxTrack_YZ_GaussSigmaZ**: The cluster size in Z of the main most energetic track in YZ projection.
-/// * **MaxTrack_XYZ_GaussSigmaZ**: The cluster size in Z of the main most energetic track in the combines
+/// * **MaxTrack_XYZ_GaussSigmaZ**: The cluster size in Z of the main most energetic track in the combined
 /// XZ and YZ projections.
 /// * **SecondMaxTrackGaussSigmaX**: The cluster size in X of the second most energetic track.
 /// * **SecondMaxTrackGaussSigmaY**: The cluster size in Y of the second most energetic track.
@@ -429,7 +429,8 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     for (int tck = 0; tck < fInputTrackEvent->GetNumberOfTracks(); tck++)
         fOutputTrackEvent->AddTrack(fInputTrackEvent->GetTrack(tck));
 
-    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) fInputTrackEvent->PrintOnlyTracks();
+    if (this->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
+        fInputTrackEvent->PrintOnlyTracks();
 
     /* {{{ Number of tracks observables */
     Int_t nTracksX = 0, nTracksY = 0, nTracksXYZ = 0;
@@ -873,7 +874,7 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         tckMaxXYZ_SigmaY = fInputTrackEvent->GetMaxEnergyTrack()->GetHits()->GetSigmaY();
         tckMaxXYZ_SigmaZ = fInputTrackEvent->GetMaxEnergyTrack()->GetHits()->GetSigmaZ2();
         RESTDebug << "id: " << fInputTrackEvent->GetID() << " " << fInputTrackEvent->GetSubEventTag()
-              << " tckMaxEnXYZ: " << tckMaxEnXYZ << RESTendl;
+                  << " tckMaxEnXYZ: " << tckMaxEnXYZ << RESTendl;
         tckMaxXYZ_gausSigmaX = fInputTrackEvent->GetMaxEnergyTrack()->GetHits()->GetGaussSigmaX();
         tckMaxXYZ_gausSigmaY = fInputTrackEvent->GetMaxEnergyTrack()->GetHits()->GetGaussSigmaY();
         tckMaxXYZ_gausSigmaZ = fInputTrackEvent->GetMaxEnergyTrack()->GetHits()->GetGaussSigmaZ();
@@ -893,7 +894,7 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         tckMaxXZ_gausSigmaX = fInputTrackEvent->GetMaxEnergyTrack("X")->GetHits()->GetGaussSigmaX();
         tckMaxXZ_gausSigmaZ_XZ = fInputTrackEvent->GetMaxEnergyTrack("X")->GetHits()->GetGaussSigmaZ();
         RESTDebug << "id: " << fInputTrackEvent->GetID() << " " << fInputTrackEvent->GetSubEventTag()
-              << " tckMaxEnX: " << tckMaxEnX << RESTendl;
+                  << " tckMaxEnX: " << tckMaxEnX << RESTendl;
     }
 
     SetObservableValue((string) "MaxTrackEnergy_X", tckMaxEnX);
@@ -909,7 +910,7 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         tckMaxYZ_gausSigmaY = fInputTrackEvent->GetMaxEnergyTrack("Y")->GetHits()->GetGaussSigmaY();
         tckMaxYZ_gausSigmaZ_YZ = fInputTrackEvent->GetMaxEnergyTrack("Y")->GetHits()->GetGaussSigmaZ();
         RESTDebug << "id: " << fInputTrackEvent->GetID() << " " << fInputTrackEvent->GetSubEventTag()
-              << " tckMaxEnY: " << tckMaxEnY << RESTendl;
+                  << " tckMaxEnY: " << tckMaxEnY << RESTendl;
     }
 
     SetObservableValue((string) "MaxTrackEnergy_Y", tckMaxEnY);
@@ -931,6 +932,12 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     SetObservableValue((string) "MaxTrackEnergy", tckMaxEnergy);
     SetObservableValue((string) "MaxTrackEnergyRatio", trackEnergyRatio);
+
+    SetObservableValue("MaxTrackZSigmaBalanceGaus", (tckMaxXZ_gausSigmaZ_XZ - tckMaxYZ_gausSigmaZ_YZ) /
+                                                        (tckMaxXZ_gausSigmaZ_XZ + tckMaxYZ_gausSigmaZ_YZ));
+
+    SetObservableValue("MaxTrackZSigmaBalance",
+                       (tckMaxXZ_SigmaZ - tckMaxYZ_SigmaZ) / (tckMaxXZ_SigmaZ + tckMaxYZ_SigmaZ));
 
     TRestHits hits;
     TRestHits* hitsXZ = nullptr;

--- a/src/TRestTrackAnalysisProcess.cxx
+++ b/src/TRestTrackAnalysisProcess.cxx
@@ -148,14 +148,14 @@
 /// * **MaxTrack_XYZ_GaussSigmaZ**: The cluster size in Z of the main most energetic track in the combined
 /// XZ and YZ projections.
 /// * **MaxTrackxySigmaGausBalance**: (gausSigma_x-gausSigma_y)/(gausSigma_x+gausSigma_y).
-/// * **MaxTrackZSigmaBalanceGaus**: (gausSigmaZ_XZ - gausSigmaZ_YZ) /(gausSigmaZ_XZ + gausSigmaZ_YZ).
+/// * **MaxTrackZSigmaGausBalance**: (gausSigmaZ_XZ - gausSigmaZ_YZ) /(gausSigmaZ_XZ + gausSigmaZ_YZ).
 /// * **SecondMaxTrackGaussSigmaX**: The cluster size in X of the second most energetic track.
 /// * **SecondMaxTrackGaussSigmaY**: The cluster size in Y of the second most energetic track.
 /// * **SecondMaxTrack_XZ_GaussSigmaX**: The cluster size in X of the second most energetic track in XZ
 /// projection.
 /// * **SecondMaxTrack_YZ_GaussSigmaY**: The cluster size in Y of the second most energetic track in YZ
 /// projection.
-/// * **SecondMaxTrackxySigmaBalanceGaus**:
+/// * **SecondMaxTrackxySigmaGausBalance**:
 /// (secondGausSigma_x-secondGausSigma_y)/(secondGausSigma_x+secondGausSigma_y).
 ///
 /// Time observables:
@@ -937,7 +937,7 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue((string) "MaxTrackEnergy", tckMaxEnergy);
     SetObservableValue((string) "MaxTrackEnergyRatio", trackEnergyRatio);
 
-    SetObservableValue("MaxTrackZSigmaBalanceGaus", (tckMaxXZ_gausSigmaZ_XZ - tckMaxYZ_gausSigmaZ_YZ) /
+    SetObservableValue("MaxTrackZSigmaGausBalance", (tckMaxXZ_gausSigmaZ_XZ - tckMaxYZ_gausSigmaZ_YZ) /
                                                         (tckMaxXZ_gausSigmaZ_XZ + tckMaxYZ_gausSigmaZ_YZ));
 
     SetObservableValue("MaxTrackZSigmaBalance",
@@ -1048,7 +1048,7 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("SecondMaxTrackxy2SigmaBalance", (tckSecondMaxXZ_SigmaZ - tckSecondMaxYZ_SigmaZ) /
                                                             (tckSecondMaxXZ_SigmaZ + tckSecondMaxYZ_SigmaZ));
 
-    SetObservableValue("SecondMaxTrackZSigmaBalanceGaus",
+    SetObservableValue("SecondMaxTrackZSigmaGausBalance",
                        (tckSecondMaxXZ_gausSigmaZ_XZ - tckSecondMaxYZ_gausSigmaZ_YZ) /
                            (tckSecondMaxXZ_gausSigmaZ_XZ + tckSecondMaxYZ_gausSigmaZ_YZ));
 

--- a/src/TRestTrackAnalysisProcess.cxx
+++ b/src/TRestTrackAnalysisProcess.cxx
@@ -127,13 +127,13 @@
 /// * **MaxTrackSigmaZ**: The cluster size in Z of the main most energetic track.
 /// * **MaxTrack_XZ_SigmaX**: The cluster size in X of the main most energetic track in XZ projection.
 /// * **MaxTrack_YZ_SigmaY**: The cluster size in Y of the main most energetic track in YZ projection.
-/// * **MaxTrackxySigmaBalanceGaus**: (gausSigma_x-gausSigma_y)/(gausSigma_x+gausSigma_y).
+/// * **MaxTrackZSigmaBalance**: (sigmaZ_XZ - sigmaZ_YZ) /(sigmaZ_XZ + sigmaZ_YZ).
+/// * **MaxTrackxySigmaBalance**: (sigmaX - sigmaY) /(sigmaX + sigmaY).
 /// * **SecondMaxTrackSigmaX**: The cluster size in X of the second most energetic track.
 /// * **SecondMaxTrackSigmaY**: The cluster size in Y of the second most energetic track.
 /// * **SecondMaxTrack_XZ_SigmaX**: The cluster size in X of the second most energetic track in XZ projection.
 /// * **SecondMaxTrack_YZ_SigmaY**: The cluster size in Y of the second most energetic track in YZ projection.
-/// * **SecondMaxTrackxySigmaBalanceGaus**:
-/// (secondGausSigma_x-secondGausSigma_y)/(secondGausSigma_x+secondGausSigma_y).
+
 ///
 /// The gaussian sigma parameter measures the cluster size obtained from the fit to a gaussian of a given
 /// track hits.
@@ -147,12 +147,16 @@
 /// * **MaxTrack_YZ_GaussSigmaZ**: The cluster size in Z of the main most energetic track in YZ projection.
 /// * **MaxTrack_XYZ_GaussSigmaZ**: The cluster size in Z of the main most energetic track in the combined
 /// XZ and YZ projections.
+/// * **MaxTrackxySigmaGausBalance**: (gausSigma_x-gausSigma_y)/(gausSigma_x+gausSigma_y).
+/// * **MaxTrackZSigmaBalanceGaus**: (gausSigmaZ_XZ - gausSigmaZ_YZ) /(gausSigmaZ_XZ + gausSigmaZ_YZ).
 /// * **SecondMaxTrackGaussSigmaX**: The cluster size in X of the second most energetic track.
 /// * **SecondMaxTrackGaussSigmaY**: The cluster size in Y of the second most energetic track.
 /// * **SecondMaxTrack_XZ_GaussSigmaX**: The cluster size in X of the second most energetic track in XZ
 /// projection.
 /// * **SecondMaxTrack_YZ_GaussSigmaY**: The cluster size in Y of the second most energetic track in YZ
 /// projection.
+/// * **SecondMaxTrackxySigmaBalanceGaus**:
+/// (secondGausSigma_x-secondGausSigma_y)/(secondGausSigma_x+secondGausSigma_y).
 ///
 /// Time observables:
 ///
@@ -915,14 +919,14 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     SetObservableValue((string) "MaxTrackEnergy_Y", tckMaxEnY);
     SetObservableValue((string) "MaxTrack_YZ_SigmaY", tckMaxYZ_SigmaY);
-    SetObservableValue((string) "MaxTrack_YZ_SigmaZ", tckMaxYZ_SigmaY);
+    SetObservableValue((string) "MaxTrack_YZ_SigmaZ", tckMaxYZ_SigmaZ);
     SetObservableValue((string) "MaxTrack_YZ_GaussSigmaY", tckMaxYZ_gausSigmaY);
     SetObservableValue((string) "MaxTrack_YZ_GaussSigmaZ", tckMaxYZ_gausSigmaZ_YZ);
 
-    SetObservableValue("MaxTrackxy2SigmaGaus", (tckMaxXZ_gausSigmaX * tckMaxXZ_gausSigmaX) +
-                                                   (tckMaxYZ_gausSigmaY * tckMaxYZ_gausSigmaY));
-    SetObservableValue("MaxTrackxySigmaBalanceGaus", (tckMaxXZ_gausSigmaX - tckMaxYZ_gausSigmaY) /
-                                                         (tckMaxXZ_gausSigmaX + tckMaxYZ_gausSigmaY));
+    SetObservableValue("MaxTrackxySigmaGausBalance", (tckMaxXZ_gausSigmaX * tckMaxXZ_gausSigmaX) +
+                                                         (tckMaxYZ_gausSigmaY * tckMaxYZ_gausSigmaY));
+    SetObservableValue("MaxTrackxySigmaBalance",
+                       (tckMaxXZ_SigmaX - tckMaxYZ_SigmaY) / (tckMaxXZ_SigmaX + tckMaxYZ_SigmaY));
 
     Double_t tckMaxEnergy = tckMaxEnX + tckMaxEnY + tckMaxEnXYZ;
 
@@ -1038,12 +1042,18 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue((string) "SecondMaxTrack_YZ_GaussSigmaY", tckSecondMaxYZ_gausSigmaY);
     SetObservableValue((string) "SecondMaxTrack_YZ_GaussSigmaZ", tckSecondMaxYZ_gausSigmaZ_YZ);
 
-    SetObservableValue("SecondMaxTrackxy2SigmaGaus",
+    SetObservableValue("SecondMaxTrackxySigmaGausBalance",
                        (tckSecondMaxXZ_gausSigmaX * tckSecondMaxXZ_gausSigmaX) +
                            (tckSecondMaxYZ_gausSigmaY * tckSecondMaxYZ_gausSigmaY));
-    SetObservableValue("SecondMaxTrackxySigmaBalanceGaus",
-                       (tckSecondMaxXZ_gausSigmaX - tckSecondMaxYZ_gausSigmaY) /
-                           (tckSecondMaxXZ_gausSigmaX + tckSecondMaxYZ_gausSigmaY));
+    SetObservableValue("SecondMaxTrackxy2SigmaBalance", (tckSecondMaxXZ_SigmaZ - tckSecondMaxYZ_SigmaZ) /
+                                                            (tckSecondMaxXZ_SigmaZ + tckSecondMaxYZ_SigmaZ));
+
+    SetObservableValue("SecondMaxTrackZSigmaBalanceGaus",
+                       (tckSecondMaxXZ_gausSigmaZ_XZ - tckSecondMaxYZ_gausSigmaZ_YZ) /
+                           (tckSecondMaxXZ_gausSigmaZ_XZ + tckSecondMaxYZ_gausSigmaZ_YZ));
+
+    SetObservableValue("SecondMaxTrackZSigmaBalance",
+                       (tckMaxXZ_SigmaZ - tckMaxYZ_SigmaZ) / (tckMaxXZ_SigmaZ + tckMaxYZ_SigmaZ));
     /* }}} */
 
     /* {{{ Track Length observables (MaxTrackLength_XX) */


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Ok: 38](https://badgen.net/badge/PR%20Size/Ok%3A%2038/green) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/cris_trackSigmaZBalance/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/cris_trackSigmaZBalance) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/cris_trackSigmaZBalance/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/cris_trackSigmaZBalance)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The sigma and gauss sigma balance in Z is computed for the first track.