### PR TITLE
New methods added for track analysis

### DIFF
--- a/inc/TRestTrackEvent.h
+++ b/inc/TRestTrackEvent.h
@@ -112,6 +112,7 @@ class TRestTrackEvent : public TRestEvent {
     void GetMaxTrackBoundaries(TVector3& orig, TVector3& end);
     void GetOriginEnd(std::vector<TGraph*>& originGr, std::vector<TGraph*>& endGr,
                       std::vector<TLegend*>& leg);
+    TRestVolumeHits GetMaxTrackBoundaries3D(TVector3& orig, TVector3& end);
     void DrawOriginEnd(TPad* pad, std::vector<TGraph*>& originGr, std::vector<TGraph*>& endGr,
                        std::vector<TLegend*>& leg);
 

--- a/inc/TRestTrackEvent.h
+++ b/inc/TRestTrackEvent.h
@@ -108,6 +108,7 @@ class TRestTrackEvent : public TRestEvent {
 
     Int_t GetOriginTrackID(Int_t tck);
 
+    Double_t GetMaxTrackRelativeZ();
     void GetMaxTrackBoundaries(TVector3& orig, TVector3& end);
     void GetOriginEnd(std::vector<TGraph*>& originGr, std::vector<TGraph*>& endGr,
                       std::vector<TLegend*>& leg);

--- a/inc/TRestTrackLineAnalysisProcess.h
+++ b/inc/TRestTrackLineAnalysisProcess.h
@@ -31,12 +31,12 @@
 class TRestTrackLineAnalysisProcess : public TRestEventProcess {
    private:
     /// A pointer to the input event Track Event
-    TRestTrackEvent* fTrackEvent; //!
+    TRestTrackEvent* fTrackEvent;  //!
 
     /// A pointer to the output event Track event
-    TRestTrackEvent* fOutTrackEvent; //!
+    TRestTrackEvent* fOutTrackEvent;  //!
 
-    std::string fLineAnaMethod = "default"; //<
+    std::string fLineAnaMethod = "default";  //<
 
     void Initialize() override;
 

--- a/inc/TRestTrackLineAnalysisProcess.h
+++ b/inc/TRestTrackLineAnalysisProcess.h
@@ -36,7 +36,7 @@ class TRestTrackLineAnalysisProcess : public TRestEventProcess {
     /// A pointer to the output event Track event
     TRestTrackEvent* fOutTrackEvent;
 
-    std::string fLineAnaMethod="default";
+    std::string fLineAnaMethod = "default";
 
     void Initialize() override;
 
@@ -51,7 +51,7 @@ class TRestTrackLineAnalysisProcess : public TRestEventProcess {
 
     void PrintMetadata() override {
         BeginPrintProcess();
-        RESTMetadata << "Track Analysis method "<< fLineAnaMethod << RESTendl;
+        RESTMetadata << "Track Analysis method " << fLineAnaMethod << RESTendl;
         EndPrintProcess();
     }
 

--- a/inc/TRestTrackLineAnalysisProcess.h
+++ b/inc/TRestTrackLineAnalysisProcess.h
@@ -31,12 +31,12 @@
 class TRestTrackLineAnalysisProcess : public TRestEventProcess {
    private:
     /// A pointer to the input event Track Event
-    TRestTrackEvent* fTrackEvent;
+    TRestTrackEvent* fTrackEvent; //!
 
     /// A pointer to the output event Track event
-    TRestTrackEvent* fOutTrackEvent;
+    TRestTrackEvent* fOutTrackEvent; //!
 
-    std::string fLineAnaMethod = "default";
+    std::string fLineAnaMethod = "default"; //<
 
     void Initialize() override;
 

--- a/inc/TRestTrackLineAnalysisProcess.h
+++ b/inc/TRestTrackLineAnalysisProcess.h
@@ -36,6 +36,8 @@ class TRestTrackLineAnalysisProcess : public TRestEventProcess {
     /// A pointer to the output event Track event
     TRestTrackEvent* fOutTrackEvent;
 
+    std::string fLineAnaMethod="default";
+
     void Initialize() override;
 
    protected:
@@ -49,6 +51,7 @@ class TRestTrackLineAnalysisProcess : public TRestEventProcess {
 
     void PrintMetadata() override {
         BeginPrintProcess();
+        RESTMetadata << "Track Analysis method "<< fLineAnaMethod << RESTendl;
         EndPrintProcess();
     }
 
@@ -59,6 +62,6 @@ class TRestTrackLineAnalysisProcess : public TRestEventProcess {
     // Destructor
     ~TRestTrackLineAnalysisProcess();
 
-    ClassDefOverride(TRestTrackLineAnalysisProcess, 1);
+    ClassDefOverride(TRestTrackLineAnalysisProcess, 2);
 };
 #endif

--- a/src/TRestTrackEvent.cxx
+++ b/src/TRestTrackEvent.cxx
@@ -317,7 +317,7 @@ void TRestTrackEvent::SetLevels() {
 /// \brief This function retrieves the origin and the end track positions
 /// based after the reconstruction of a 3D track. It requires the track to have
 /// the same number of hits in X and Y. Two different directions are scanned and
-/// the one which maximize the track length is retreived. Afterwards the position
+/// the one which maximizes the track length is retrieved. Afterwards the position
 /// of the closer hit to the half integral of the track is obtained. Then, the origin
 /// of the track is defined as the further edge to the half integral, while the track
 /// end is defined as the closest edge.

--- a/src/TRestTrackEvent.cxx
+++ b/src/TRestTrackEvent.cxx
@@ -323,10 +323,17 @@ void TRestTrackEvent::SetLevels() {
 /// end is defined as the closest edge.
 ///
 TRestVolumeHits TRestTrackEvent::GetMaxTrackBoundaries3D(TVector3& orig, TVector3& end) {
-    TRestVolumeHits hitsX = (TRestVolumeHits) * (GetMaxEnergyTrackInX()->GetVolumeHits());
-    TRestVolumeHits hitsY = (TRestVolumeHits) * (GetMaxEnergyTrackInY()->GetVolumeHits());
 
-    double totEn = 0;
+    TRestTrack* tckX = GetMaxEnergyTrackInX();
+    TRestTrack* tckY = GetMaxEnergyTrackInY();
+
+    if(tckX == nullptr || tckY == nullptr){
+      RESTWarning << "Track is empty, skipping"<<RESTendl;
+      return {};
+    }
+
+    TRestVolumeHits hitsX = (TRestVolumeHits) * (tckX->GetVolumeHits());
+    TRestVolumeHits hitsY = (TRestVolumeHits) * (tckY->GetVolumeHits());
 
     const int nHits = std::min(hitsX.GetNumberOfHits(), hitsY.GetNumberOfHits());
     TRestVolumeHits best3DHits, hits3D;
@@ -343,13 +350,17 @@ TRestVolumeHits TRestTrackEvent::GetMaxTrackBoundaries3D(TVector3& orig, TVector
         posYZ = hitsY.GetZ(j);
         avgZ = (enX * posXZ + enY * posYZ) / (enX + enY);
         hits3D.AddHit(hitsX.GetX(i), hitsY.GetY(j), avgZ, enX + enY, 0, XYZ, 0, 0, 0);
-        totEn += enX + enY;
     }
 
     double length = (best3DHits.GetPosition(0) - best3DHits.GetPosition(nHits - 1)).Mag();
 
     if ((hits3D.GetPosition(0) - hits3D.GetPosition(nHits - 1)).Mag() > length) {
         best3DHits = hits3D;
+    }
+
+    double totEn =0;
+    for (unsigned int i = 0; i < best3DHits.GetNumberOfHits(); i++) {
+        totEn += best3DHits.GetEnergy(i);
     }
 
     const TVector3 pos0 = best3DHits.GetPosition(0);
@@ -391,6 +402,11 @@ void TRestTrackEvent::GetMaxTrackBoundaries(TVector3& orig, TVector3& end) {
     TRestTrack* tckX = GetMaxEnergyTrackInX();
     TRestTrack* tckY = GetMaxEnergyTrackInY();
 
+    if(tckX == nullptr || tckY == nullptr){
+      RESTWarning << "Track is empty, skipping"<<RESTendl;
+      return;
+    }
+
     TVector3 origX, endX;
     // Retreive origin and end of the track for the XZ projection
     tckX->GetBoundaries(origX, endX);
@@ -412,6 +428,11 @@ void TRestTrackEvent::GetMaxTrackBoundaries(TVector3& orig, TVector3& end) {
 Double_t TRestTrackEvent::GetMaxTrackRelativeZ() {
     TRestTrack* tckX = GetMaxEnergyTrackInX();
     TRestTrack* tckY = GetMaxEnergyTrackInY();
+
+    if(tckX == nullptr || tckY == nullptr){
+      RESTWarning << "Track is empty, skipping"<<RESTendl;
+      return -1;
+    }
 
     std::vector<std::pair<double, double> > zEn;
     double totEn = 0;

--- a/src/TRestTrackEvent.cxx
+++ b/src/TRestTrackEvent.cxx
@@ -323,13 +323,12 @@ void TRestTrackEvent::SetLevels() {
 /// end is defined as the closest edge.
 ///
 TRestVolumeHits TRestTrackEvent::GetMaxTrackBoundaries3D(TVector3& orig, TVector3& end) {
-
     TRestTrack* tckX = GetMaxEnergyTrackInX();
     TRestTrack* tckY = GetMaxEnergyTrackInY();
 
-    if(tckX == nullptr || tckY == nullptr){
-      RESTWarning << "Track is empty, skipping"<<RESTendl;
-      return {};
+    if (tckX == nullptr || tckY == nullptr) {
+        RESTWarning << "Track is empty, skipping" << RESTendl;
+        return {};
     }
 
     TRestVolumeHits hitsX = (TRestVolumeHits) * (tckX->GetVolumeHits());
@@ -358,7 +357,7 @@ TRestVolumeHits TRestTrackEvent::GetMaxTrackBoundaries3D(TVector3& orig, TVector
         best3DHits = hits3D;
     }
 
-    double totEn =0;
+    double totEn = 0;
     for (unsigned int i = 0; i < best3DHits.GetNumberOfHits(); i++) {
         totEn += best3DHits.GetEnergy(i);
     }
@@ -402,9 +401,9 @@ void TRestTrackEvent::GetMaxTrackBoundaries(TVector3& orig, TVector3& end) {
     TRestTrack* tckX = GetMaxEnergyTrackInX();
     TRestTrack* tckY = GetMaxEnergyTrackInY();
 
-    if(tckX == nullptr || tckY == nullptr){
-      RESTWarning << "Track is empty, skipping"<<RESTendl;
-      return;
+    if (tckX == nullptr || tckY == nullptr) {
+        RESTWarning << "Track is empty, skipping" << RESTendl;
+        return;
     }
 
     TVector3 origX, endX;
@@ -429,9 +428,9 @@ Double_t TRestTrackEvent::GetMaxTrackRelativeZ() {
     TRestTrack* tckX = GetMaxEnergyTrackInX();
     TRestTrack* tckY = GetMaxEnergyTrackInY();
 
-    if(tckX == nullptr || tckY == nullptr){
-      RESTWarning << "Track is empty, skipping"<<RESTendl;
-      return -1;
+    if (tckX == nullptr || tckY == nullptr) {
+        RESTWarning << "Track is empty, skipping" << RESTendl;
+        return -1;
     }
 
     std::vector<std::pair<double, double> > zEn;

--- a/src/TRestTrackEvent.cxx
+++ b/src/TRestTrackEvent.cxx
@@ -406,7 +406,7 @@ void TRestTrackEvent::GetMaxTrackBoundaries(TVector3& orig, TVector3& end) {
 }
 
 ///////////////////////////////////////////////
-/// \brief Function calculate the relative Z of the maximum
+/// \brief Function to calculate the relative Z of the most energetic
 /// track to cross check if the track is upwards or downwards
 ///
 Double_t TRestTrackEvent::GetMaxTrackRelativeZ() {

--- a/src/TRestTrackEvent.cxx
+++ b/src/TRestTrackEvent.cxx
@@ -407,7 +407,7 @@ void TRestTrackEvent::GetMaxTrackBoundaries(TVector3& orig, TVector3& end) {
 
 ///////////////////////////////////////////////
 /// \brief Function to calculate the relative Z of the most energetic
-/// track to cross check if the track is upwards or downwards
+/// track to crosscheck if the track is upwards or downwards
 ///
 Double_t TRestTrackEvent::GetMaxTrackRelativeZ() {
     TRestTrack* tckX = GetMaxEnergyTrackInX();

--- a/src/TRestTrackEvent.cxx
+++ b/src/TRestTrackEvent.cxx
@@ -314,7 +314,7 @@ void TRestTrackEvent::SetLevels() {
 }
 
 ///////////////////////////////////////////////
-/// \brief This function retreive the origin and the end of the track
+/// \brief This function retrieves the origin and the end track positions
 /// based after the reconstruction of a 3D track. It requires the track to have
 /// the same number of hits in X and Y. Two different directions are scanned and
 /// the one which maximize the track length is retreived. Afterwards the position

--- a/src/TRestTrackEvent.cxx
+++ b/src/TRestTrackEvent.cxx
@@ -337,6 +337,49 @@ void TRestTrackEvent::GetMaxTrackBoundaries(TVector3& orig, TVector3& end) {
     end = TVector3(endX.X(), endY.Y(), endZ);
 }
 
+///////////////////////////////////////////////
+/// \brief Function calculate the relative Z of the maximum
+/// track to cross check if the track is upwards or downwards
+///
+Double_t TRestTrackEvent::GetMaxTrackRelativeZ() {
+    TRestTrack* tckX = GetMaxEnergyTrackInX();
+    TRestTrack* tckY = GetMaxEnergyTrackInY();
+
+    std::vector<std::pair<double, double> > zEn;
+    double totEn = 0;
+
+    for (size_t i = 0; i < tckX->GetVolumeHits()->GetNumberOfHits(); i++) {
+        double en = tckX->GetVolumeHits()->GetEnergy(i);
+        double z = tckX->GetVolumeHits()->GetZ(i);
+        zEn.push_back(std::make_pair(z, en));
+        totEn += en;
+    }
+
+    for (size_t i = 0; i < tckY->GetVolumeHits()->GetNumberOfHits(); i++) {
+        double en = tckY->GetVolumeHits()->GetEnergy(i);
+        double z = tckY->GetVolumeHits()->GetZ(i);
+        zEn.push_back(std::make_pair(z, en));
+        totEn += en;
+    }
+
+    std::sort(zEn.begin(), zEn.end());
+
+    double integ = 0;
+    size_t pos = 0;
+    for (pos = 0; pos < zEn.size(); pos++) {
+        integ += zEn[pos].second;
+        if (integ >= totEn / 2.) break;
+    }
+
+    double length = zEn.front().first - zEn.back().first;
+    double diff = zEn.front().first - zEn[pos].first;
+
+    if (length == 0)
+        return 0;
+    else
+        return diff / length;
+}
+
 void TRestTrackEvent::PrintOnlyTracks() {
     cout << "TrackEvent " << GetID() << endl;
     cout << "-----------------------" << endl;

--- a/src/TRestTrackLineAnalysisProcess.cxx
+++ b/src/TRestTrackLineAnalysisProcess.cxx
@@ -50,6 +50,8 @@
 /// * **angle**: Track polar angle in radians
 /// * **downwards**: (bool) true if the track direction is downwards, false otherwise
 /// * **totalEnergy**: Energy of the track
+/// * **relativeZ**: Relative Z position in which the half of the integral is reached,
+/// when this value is below 0.5 it means that the track is downwards and upwards otherwise
 ///
 /// ### Examples
 /// \code
@@ -140,7 +142,7 @@ TRestEvent* TRestTrackLineAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) 
     Double_t angle = -10;
     bool downwards = true;
     Double_t trackEnergyX = 0, trackEnergyY = 0;
-    Double_t trackBalanceX = 0, trackBalanceY = 0, trackBalance = 0;
+    Double_t trackBalanceX = 0, trackBalanceY = 0, trackBalance = 0, relZ = 0;
 
     if (tckX && tckY) {
         // Retreive origin and end of the track for the XZ projection
@@ -167,6 +169,7 @@ TRestEvent* TRestTrackLineAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) 
         if (trackEnergyX > 0 && trackEnergyY > 0)
             trackBalance =
                 (trackEnergyX + trackEnergyY) / (fTrackEvent->GetEnergy("X") + fTrackEvent->GetEnergy("Y"));
+        relZ = fTrackEvent->GetMaxTrackRelativeZ();
     }
 
     Double_t trackEnergy = trackEnergyX + trackEnergyY;
@@ -185,6 +188,7 @@ TRestEvent* TRestTrackLineAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) 
     SetObservableValue("angle", angle);
     SetObservableValue("downwards", downwards);
     SetObservableValue("totalEnergy", trackEnergy);
+    SetObservableValue("relativeZ", relZ);
 
     if (!tckX || !tckY) return nullptr;
 

--- a/src/TRestTrackLineAnalysisProcess.cxx
+++ b/src/TRestTrackLineAnalysisProcess.cxx
@@ -34,7 +34,8 @@
 /// length, energy and downwards (bool).
 ///
 /// ### Parameters
-/// None
+/// * **lineAnaMethod**: Method to evaluate the origin and end of the track, currently
+/// 3D method and default are implemented
 ///
 /// ### Observables
 /// * **trackBalanceXZ**: Track balance between the most energetic track and all tracks in the XZ projection
@@ -146,7 +147,17 @@ TRestEvent* TRestTrackLineAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) 
 
     if (tckX && tckY) {
         // Retreive origin and end of the track for the XZ projection
-        fTrackEvent->GetMaxTrackBoundaries(orig, end);
+        if (fLineAnaMethod == "3D") {
+            fTrackEvent->GetMaxTrackBoundaries3D(orig, end);
+        } else {
+            if (fLineAnaMethod != "default") {
+                RESTWarning
+                    << "Line analysis method " << fLineAnaMethod
+                    << " is not implemented, supported methods are: default and 3D. Falling back to default."
+                    << RESTendl;
+            }
+            fTrackEvent->GetMaxTrackBoundaries(orig, end);
+        }
 
         RESTDebug << "Origin: " << orig.X() << " y: " << orig.Y() << " z: " << orig.Z() << RESTendl;
         RESTDebug << "End : " << end.X() << " y: " << end.Y() << " z: " << end.Z() << RESTendl;


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Medium: 157](https://badgen.net/badge/PR%20Size/Medium%3A%20157/orange) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/trackLineAna/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/trackLineAna) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/trackLineAna/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/trackLineAna)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

New methods were added in `TRestTrackLineAnalysisProcess` and implemented under `TRestTrackEvent`:

-  New observable added `relativeZ` that computes the relative Z position of the track to determine if it is `upwards` or `downwards`
- New method to reconstruct the track in 3D and retreive the origin and the end of the track