### PR TITLE
Removal of custom typedef any since it is misleading with std::any

### DIFF
--- a/inc/TRestTrackAnalysisProcess.h
+++ b/inc/TRestTrackAnalysisProcess.h
@@ -139,8 +139,8 @@ class TRestTrackAnalysisProcess : public TRestEventProcess {
     Double_t fDeltaEnergy;
 
    public:
-    any GetInputEvent() const override { return fInputTrackEvent; }
-    any GetOutputEvent() const override { return fOutputTrackEvent; }
+    RESTValue GetInputEvent() const override { return fInputTrackEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputTrackEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestTrackBlobAnalysisProcess.h
+++ b/inc/TRestTrackBlobAnalysisProcess.h
@@ -96,8 +96,8 @@ class TRestTrackBlobAnalysisProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fInputTrackEvent; }
-    any GetOutputEvent() const override { return fOutputTrackEvent; }
+    RESTValue GetInputEvent() const override { return fInputTrackEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputTrackEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestTrackDetachIsolatedNodesProcess.h
+++ b/inc/TRestTrackDetachIsolatedNodesProcess.h
@@ -35,8 +35,8 @@ class TRestTrackDetachIsolatedNodesProcess : public TRestEventProcess {
 
    protected:
    public:
-    any GetInputEvent() const override { return fInputTrackEvent; }
-    any GetOutputEvent() const override { return fOutputTrackEvent; }
+    RESTValue GetInputEvent() const override { return fInputTrackEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputTrackEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestTrackLineAnalysisProcess.h
+++ b/inc/TRestTrackLineAnalysisProcess.h
@@ -42,8 +42,8 @@ class TRestTrackLineAnalysisProcess : public TRestEventProcess {
 
    protected:
    public:
-    any GetInputEvent() const override { return fTrackEvent; }
-    any GetOutputEvent() const override { return fOutTrackEvent; }
+    RESTValue GetInputEvent() const override { return fTrackEvent; }
+    RESTValue GetOutputEvent() const override { return fOutTrackEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestTrackLinearizationProcess.h
+++ b/inc/TRestTrackLinearizationProcess.h
@@ -40,8 +40,8 @@ class TRestTrackLinearizationProcess : public TRestEventProcess {
     Int_t fMaxNodes = 6;
 
    public:
-    any GetInputEvent() const override { return fTrackEvent; }
-    any GetOutputEvent() const override { return fOutTrackEvent; }
+    RESTValue GetInputEvent() const override { return fTrackEvent; }
+    RESTValue GetOutputEvent() const override { return fOutTrackEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestTrackPathMinimizationProcess.h
+++ b/inc/TRestTrackPathMinimizationProcess.h
@@ -34,8 +34,8 @@ class TRestTrackPathMinimizationProcess : public TRestEventProcess {
                              // is connected to last hit)
 
    public:
-    any GetInputEvent() const override { return fInputTrackEvent; }
-    any GetOutputEvent() const override { return fOutputTrackEvent; }
+    RESTValue GetInputEvent() const override { return fInputTrackEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputTrackEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestTrackPointLikeAnalysisProcess.h
+++ b/inc/TRestTrackPointLikeAnalysisProcess.h
@@ -34,8 +34,8 @@ class TRestTrackPointLikeAnalysisProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fTrackEvent; }
-    any GetOutputEvent() const override { return fTrackEvent; }
+    RESTValue GetInputEvent() const override { return fTrackEvent; }
+    RESTValue GetOutputEvent() const override { return fTrackEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestTrackReconnectionProcess.h
+++ b/inc/TRestTrackReconnectionProcess.h
@@ -37,8 +37,8 @@ class TRestTrackReconnectionProcess : public TRestEventProcess {
 
    protected:
    public:
-    any GetInputEvent() const override { return fInputTrackEvent; }
-    any GetOutputEvent() const override { return fOutputTrackEvent; }
+    RESTValue GetInputEvent() const override { return fInputTrackEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputTrackEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestTrackReductionProcess.h
+++ b/inc/TRestTrackReductionProcess.h
@@ -34,8 +34,8 @@ class TRestTrackReductionProcess : public TRestEventProcess {
     Bool_t fKmeans = false;
 
    public:
-    any GetInputEvent() const override { return fInputTrackEvent; }
-    any GetOutputEvent() const override { return fOutputTrackEvent; }
+    RESTValue GetInputEvent() const override { return fInputTrackEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputTrackEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestTrackViewerProcess.h
+++ b/inc/TRestTrackViewerProcess.h
@@ -53,8 +53,8 @@ class TRestTrackViewerProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fTrackEvent; }
-    any GetOutputEvent() const override { return fTrackEvent; }
+    RESTValue GetInputEvent() const override { return fTrackEvent; }
+    RESTValue GetOutputEvent() const override { return fTrackEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 20](https://badgen.net/badge/PR%20Size/Ok%3A%2020/green) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/any_to_RESTValue/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/any_to_RESTValue) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/any_to_RESTValue/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/any_to_RESTValue)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Removal of custom `typedef REST_Reflection::TRestReflector any` since it is misleading with `std::any`.

The custom typedef `any` has been replaced by existing `typedef REST_Reflection::TRestReflector RESTValue`

Related PR https://github.com/rest-for-physics/framework/pull/471