### PR TITLE
Track observables for simulation events (XYZ tracks)

### DIFF
--- a/src/TRestTrackAnalysisProcess.cxx
+++ b/src/TRestTrackAnalysisProcess.cxx
@@ -1038,7 +1038,8 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     Double_t trackSecondMaxEnergy = tckSecondMaxEnergy_X + tckSecondMaxEnergy_Y;
     if (fInputTrackEvent->GetSecondMaxEnergyTrack("XYZ") != nullptr) {
-        trackSecondMaxEnergy = fInputTrackEvent->GetSecondMaxEnergyTrack("XYZ")->GetEnergy();}
+        trackSecondMaxEnergy = fInputTrackEvent->GetSecondMaxEnergyTrack("XYZ")->GetEnergy();
+    }
 
     SetObservableValue((string) "SecondMaxTrackEnergy", trackSecondMaxEnergy);
     SetObservableValue((string) "SecondMaxTrackSigmaX", tckSecondMaxXYZ_SigmaX);

--- a/src/TRestTrackAnalysisProcess.cxx
+++ b/src/TRestTrackAnalysisProcess.cxx
@@ -1037,6 +1037,8 @@ TRestEvent* TRestTrackAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     }
 
     Double_t trackSecondMaxEnergy = tckSecondMaxEnergy_X + tckSecondMaxEnergy_Y;
+    if (fInputTrackEvent->GetSecondMaxEnergyTrack("XYZ") != nullptr) {
+        trackSecondMaxEnergy = fInputTrackEvent->GetSecondMaxEnergyTrack("XYZ")->GetEnergy();}
 
     SetObservableValue((string) "SecondMaxTrackEnergy", trackSecondMaxEnergy);
     SetObservableValue((string) "SecondMaxTrackSigmaX", tckSecondMaxXYZ_SigmaX);

--- a/src/TRestTrackEvent.cxx
+++ b/src/TRestTrackEvent.cxx
@@ -183,12 +183,12 @@ TRestTrack* TRestTrackEvent::GetSecondMaxEnergyTrack(TString option) {
 
         Double_t en = t->GetEnergy();
 
-        if (option == "X" && (t->isXZ() || t->isXYZ)) {
+        if (option == "X" && (t->isXZ() || t->isXYZ())) {
             if (en > maxEnergy) {
                 maxEnergy = t->GetEnergy();
                 track = tck;
             }
-        } else if (option == "Y" && (t->isYZ() || t->isXYZ)) {
+        } else if (option == "Y" && (t->isYZ() || t->isXYZ())) {
             if (t->GetEnergy() > maxEnergy) {
                 maxEnergy = t->GetEnergy();
                 track = tck;
@@ -226,10 +226,10 @@ Double_t TRestTrackEvent::GetEnergy(TString option) {
         if (option == "")
             en += t->GetEnergy();
 
-        else if (option == "X" && (t->isXZ() || t->isXYZ))
+        else if (option == "X" && (t->isXZ() || t->isXYZ()))
             en += t->GetEnergy();
 
-        else if (option == "Y" && (t->isYZ() || t->isXYZ))
+        else if (option == "Y" && (t->isYZ() || t->isXYZ()))
             en += t->GetEnergy();
 
         else if (option == "XYZ" && t->isXYZ())

--- a/src/TRestTrackEvent.cxx
+++ b/src/TRestTrackEvent.cxx
@@ -183,12 +183,12 @@ TRestTrack* TRestTrackEvent::GetSecondMaxEnergyTrack(TString option) {
 
         Double_t en = t->GetEnergy();
 
-        if (option == "X" && t->isXZ()) {
+        if (option == "X" && (t->isXZ() || t->isXYZ)) {
             if (en > maxEnergy) {
                 maxEnergy = t->GetEnergy();
                 track = tck;
             }
-        } else if (option == "Y" && t->isYZ()) {
+        } else if (option == "Y" && (t->isYZ() || t->isXYZ)) {
             if (t->GetEnergy() > maxEnergy) {
                 maxEnergy = t->GetEnergy();
                 track = tck;
@@ -226,10 +226,10 @@ Double_t TRestTrackEvent::GetEnergy(TString option) {
         if (option == "")
             en += t->GetEnergy();
 
-        else if (option == "X" && t->isXZ())
+        else if (option == "X" && (t->isXZ() || t->isXYZ))
             en += t->GetEnergy();
 
-        else if (option == "Y" && t->isYZ())
+        else if (option == "Y" && (t->isYZ() || t->isXYZ))
             en += t->GetEnergy();
 
         else if (option == "XYZ" && t->isXYZ())


### PR DESCRIPTION
![DavidDiezIb](https://badgen.net/badge/PR%20submitted%20by%3A/DavidDiezIb/blue) ![Ok: 7](https://badgen.net/badge/PR%20Size/Ok%3A%207/green) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/DavidDiezIb-tracksXYZ/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/DavidDiezIb-tracksXYZ) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/DavidDiezIb-tracksXYZ/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/DavidDiezIb-tracksXYZ) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Some observables doesn't work properly for simulation tracks (XYZ tracks), only for real ones (XZ or YZ tracks).
Here I try to solve this issue for SecondMaxTrackEnergy.