### PR TITLE
Correct observable definitions

### DIFF
--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -439,10 +439,10 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("MaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY[0].first]);
     SetObservableValue("MaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY[0].first]);
 
-    SetObservableValue("MaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[energiesY[0].first]);
-    SetObservableValue("MaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[energiesY[0].first]);
-    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[energiesY[0].first]);
-    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[energiesY[0].first]);
+    SetObservableValue("MaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[0]);
+    SetObservableValue("MaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[0]);
+    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[0]);
+    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[0]);
 
     SetObservableValue("MaxTrack_XZ_YZ_Energy", energiesX[0].second + energiesY[0].second);
     SetObservableValue("MaxTrack_XZ_YZ_MaxTrackEnergyPercentage",
@@ -475,12 +475,12 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("SecondMaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY[1].first]);
     SetObservableValue("SecondMaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY[1].first]);
 
-    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[energiesY[1].first]);
-    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[energiesY[1].first]);
+    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[1]);
+    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
     SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance",
-                       XZ_YZ_GaussSigmaXYBalance[energiesY[1].first]);
+                       XZ_YZ_GaussSigmaXYBalance[1]);
     SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance",
-                       XZ_YZ_GaussSigmaZBalance[energiesY[1].first]);
+                       XZ_YZ_GaussSigmaZBalance[1]);
 
     if (fTrackEvent->GetNumberOfTracks() > 1) {
         SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);

--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -477,10 +477,8 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[1]);
     SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
-    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance",
-                       XZ_YZ_GaussSigmaXYBalance[1]);
-    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance",
-                       XZ_YZ_GaussSigmaZBalance[1]);
+    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[1]);
+    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[1]);
 
     if (fTrackEvent->GetNumberOfTracks() > 1) {
         SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);


### PR DESCRIPTION
![JPorron](https://badgen.net/badge/PR%20submitted%20by%3A/JPorron/blue) ![Ok: 8](https://badgen.net/badge/PR%20Size/Ok%3A%208/green) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/jporron-tracks2D-observable-correction/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/jporron-tracks2D-observable-correction) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jporron-tracks2D-observable-correction/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jporron-tracks2D-observable-correction) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Corrected way to find some observables.

These observables are found using the function (example for the first of the changes) _**XZ_YZ_SigmaXYBalance**_, that previously used as input _**energiesY[0].first**_. This can, however, differ as the map _**energiesY**_ is sorted and these values will change (_**energiesY[0].first**_ can be 4, for example). The way the function is defined _**XZ_YZ_SigmaXYBalance[i] = (XZ_SigmaX[energiesX[i].first] - YZ_SigmaY[energiesY[i].first]) / (XZ_SigmaX[energiesX[i].first] + YZ_SigmaY[energiesY[i].first]);**_ i will be 4 in this example and will call _**XZ_SigmaX[energiesX[4].first]**_ instead of the desired _**XZ_SigmaX[energiesX[0].first]**_ that will correspond to the highest energy track, while _**XZ_SigmaX[energiesX[4].first]**_ is the 4th highest energy one. This gives a wrong result for the MaxTrack and problems can arise when there is a different number of tracks in X and Y.