### PR TITLE
Work on Tracks2D and 3D - Comment checkpoint

### DIFF
--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -414,99 +414,143 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance);
     SetObservableValue("Map_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance);
 
+
     // --- Max track observables --- //
-    /*
-        SetObservableValue("MaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX[0].first]);
-        SetObservableValue("MaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX[0].first]);
-        SetObservableValue("MaxTrack_XZ_SigmaX", XZ_SigmaX[energiesX[0].first]);
-        SetObservableValue("MaxTrack_XZ_SigmaZ", XZ_SigmaZ[energiesX[0].first]);
-        SetObservableValue("MaxTrack_XZ_GaussSigmaX", XZ_GaussSigmaX[energiesX[0].first]);
-        SetObservableValue("MaxTrack_XZ_GaussSigmaZ", XZ_GaussSigmaZ[energiesX[0].first]);
-        SetObservableValue("MaxTrack_XZ_LengthX", XZ_LengthX[energiesX[0].first]);
-        SetObservableValue("MaxTrack_XZ_VolumeX", XZ_VolumeX[energiesX[0].first]);
-        SetObservableValue("MaxTrack_XZ_MeanX", XZ_MeanX[energiesX[0].first]);
-        SetObservableValue("MaxTrack_XZ_MeanZ", XZ_MeanZ[energiesX[0].first]);
-        SetObservableValue("MaxTrack_XZ_SkewZ", XZ_SkewZ[energiesX[0].first]);
+    int energiesX0FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
+    int energiesX0SecondKey = -1;
+    int energiesY0FirstKey = -1;
+    int energiesY0SecondKey = -1;
 
-        SetObservableValue("MaxTrack_YZ_NHitsY", YZ_NHitsY[energiesY[0].first]);
-        SetObservableValue("MaxTrack_YZ_EnergyY", YZ_EnergyY[energiesY[0].first]);
-        SetObservableValue("MaxTrack_YZ_SigmaY", YZ_SigmaY[energiesY[0].first]);
-        SetObservableValue("MaxTrack_YZ_SigmaZ", YZ_SigmaZ[energiesY[0].first]);
-        SetObservableValue("MaxTrack_YZ_GaussSigmaY", YZ_GaussSigmaY[energiesY[0].first]);
-        SetObservableValue("MaxTrack_YZ_GaussSigmaZ", YZ_GaussSigmaZ[energiesY[0].first]);
-        SetObservableValue("MaxTrack_YZ_LengthY", YZ_LengthY[energiesY[0].first]);
-        SetObservableValue("MaxTrack_YZ_VolumeY", YZ_VolumeY[energiesY[0].first]);
-        SetObservableValue("MaxTrack_YZ_MeanY", YZ_MeanY[energiesY[0].first]);
-        SetObservableValue("MaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY[0].first]);
-        SetObservableValue("MaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY[0].first]);
+    // Copy the MaxTrack keys immediately after checking the vector
+    if (!energiesX.empty()) {
+        int energiesX0FirstKey = energiesX[0].first;
 
-        SetObservableValue("MaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[0]);
-        SetObservableValue("MaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[0]);
-        SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[0]);
-        SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[0]);
+        SetObservableValue("MaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX0FirstKey]);
+        SetObservableValue("MaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX0FirstKey]);
+        SetObservableValue("MaxTrack_XZ_SigmaX", XZ_SigmaX[energiesX0FirstKey]);
+        SetObservableValue("MaxTrack_XZ_SigmaZ", XZ_SigmaZ[energiesX0FirstKey]);
+        SetObservableValue("MaxTrack_XZ_GaussSigmaX", XZ_GaussSigmaX[energiesX0FirstKey]);
+        SetObservableValue("MaxTrack_XZ_GaussSigmaZ", XZ_GaussSigmaZ[energiesX0FirstKey]);
+        SetObservableValue("MaxTrack_XZ_LengthX", XZ_LengthX[energiesX0FirstKey]);
+        SetObservableValue("MaxTrack_XZ_VolumeX", XZ_VolumeX[energiesX0FirstKey]);
+        SetObservableValue("MaxTrack_XZ_MeanX", XZ_MeanX[energiesX0FirstKey]);
+        SetObservableValue("MaxTrack_XZ_MeanZ", XZ_MeanZ[energiesX0FirstKey]);
+        SetObservableValue("MaxTrack_XZ_SkewZ", XZ_SkewZ[energiesX0FirstKey]);
+    } else {
+        std::cerr << "Error: energiesX is empty. Some observables will not be set." << std::endl;
+    }
+
+    if (!energiesY.empty()) {
+        int energiesY0FirstKey = energiesY[0].first;
+
+        SetObservableValue("MaxTrack_YZ_NHitsY", YZ_NHitsY[energiesY0FirstKey]);
+        SetObservableValue("MaxTrack_YZ_EnergyY", YZ_EnergyY[energiesY0FirstKey]);
+        SetObservableValue("MaxTrack_YZ_SigmaY", YZ_SigmaY[energiesY0FirstKey]);
+        SetObservableValue("MaxTrack_YZ_SigmaZ", YZ_SigmaZ[energiesY0FirstKey]);
+        SetObservableValue("MaxTrack_YZ_GaussSigmaY", YZ_GaussSigmaY[energiesY0FirstKey]);
+        SetObservableValue("MaxTrack_YZ_GaussSigmaZ", YZ_GaussSigmaZ[energiesY0FirstKey]);
+        SetObservableValue("MaxTrack_YZ_LengthY", YZ_LengthY[energiesY0FirstKey]);
+        SetObservableValue("MaxTrack_YZ_VolumeY", YZ_VolumeY[energiesY0FirstKey]);
+        SetObservableValue("MaxTrack_YZ_MeanY", YZ_MeanY[energiesY0FirstKey]);
+        SetObservableValue("MaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY0FirstKey]);
+        SetObservableValue("MaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY0FirstKey]);
+    } else {
+        std::cerr << "Error: energiesY is empty. Some observables will not be set." << std::endl;
+    }
+
+    if (!energiesX.empty() & !energiesY.empty()) {
+        int energiesX0SecondKey = energiesX[0].second;
+        int energiesY0SecondKey = energiesY[0].second;
 
         SetObservableValue("MaxTrack_XZ_YZ_Energy", energiesX[0].second + energiesY[0].second);
         SetObservableValue("MaxTrack_XZ_YZ_MaxTrackEnergyPercentage",
-                           (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
+                        (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
         SetObservableValue("MaxTrack_XZ_YZ_EnergyBalanceXY", (energiesX[0].second - energiesY[0].second) /
-                                                                 (energiesX[0].second + energiesY[0].second));
+                                                                (energiesX[0].second + energiesY[0].second));
 
-        // --- Second max track observables --- //
-        SetObservableValue("SecondMaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX[1].first]);
-        SetObservableValue("SecondMaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX[1].first]);
-        SetObservableValue("SecondMaxTrack_XZ_SigmaX", XZ_SigmaX[energiesX[1].first]);
-        SetObservableValue("SecondMaxTrack_XZ_SigmaZ", XZ_SigmaZ[energiesX[1].first]);
-        SetObservableValue("SecondMaxTrack_XZ_GaussSigmaX", XZ_GaussSigmaX[energiesX[1].first]);
-        SetObservableValue("SecondMaxTrack_XZ_GaussSigmaZ", XZ_GaussSigmaZ[energiesX[1].first]);
-        SetObservableValue("SecondMaxTrack_XZ_LengthX", XZ_LengthX[energiesX[1].first]);
-        SetObservableValue("SecondMaxTrack_XZ_VolumeX", XZ_VolumeX[energiesX[1].first]);
-        SetObservableValue("SecondMaxTrack_XZ_MeanX", XZ_MeanX[energiesX[1].first]);
-        SetObservableValue("SecondMaxTrack_XZ_MeanZ", XZ_MeanZ[energiesX[1].first]);
-        SetObservableValue("SecondMaxTrack_XZ_SkewZ", XZ_SkewZ[energiesX[1].first]);
+    } else {
+        std::cerr << "Error: energiesX or energiesY is empty. Some observables will not be set." << std::endl;
+    }
 
-        SetObservableValue("SecondMaxTrack_YZ_NHitsY", YZ_NHitsY[energiesY[1].first]);
-        SetObservableValue("SecondMaxTrack_YZ_EnergyY", YZ_EnergyY[energiesY[1].first]);
-        SetObservableValue("SecondMaxTrack_YZ_SigmaY", YZ_SigmaY[energiesY[1].first]);
-        SetObservableValue("SecondMaxTrack_YZ_SigmaZ", YZ_SigmaZ[energiesY[1].first]);
-        SetObservableValue("SecondMaxTrack_YZ_GaussSigmaY", YZ_GaussSigmaY[energiesY[1].first]);
-        SetObservableValue("SecondMaxTrack_YZ_GaussSigmaZ", YZ_GaussSigmaZ[energiesY[1].first]);
-        SetObservableValue("SecondMaxTrack_YZ_LengthY", YZ_LengthY[energiesY[1].first]);
-        SetObservableValue("SecondMaxTrack_YZ_VolumeY", YZ_VolumeY[energiesY[1].first]);
-        SetObservableValue("SecondMaxTrack_YZ_MeanY", YZ_MeanY[energiesY[1].first]);
-        SetObservableValue("SecondMaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY[1].first]);
-        SetObservableValue("SecondMaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY[1].first]);
+    SetObservableValue("MaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[0]);
+    SetObservableValue("MaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[0]);
+    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[0]);
+    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[0]);
 
-        SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[1]);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[1]);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[1]);
+    // --- Second max track observables --- //
+    int energiesX1FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
+    int energiesX1SecondKey = -1;
+    int energiesY1FirstKey = -1;
+    int energiesY1SecondKey = -1;
 
-        if (fTrackEvent->GetNumberOfTracks() > 1) {
-            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);
-            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
-                               (energiesX[1].second + energiesY[1].second) / fTrackEvent->GetEnergy());
-            SetObservableValue(
-                "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
-                (energiesX[1].second - energiesY[1].second) / (energiesX[1].second + energiesY[1].second));
-        } else {
-            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0);
-            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0);
-            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0);
-        }
+    // Copy the SecondTrack keys immediately after checking the vector
+    if (!energiesX.empty()) {
+        int energiesX1FirstKey = energiesX[1].first;
 
-        // --- Distance obsevables between first two tracks --- //
-        SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
-        SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
-        SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
-                           TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
-                                       YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
+        SetObservableValue("SecondMaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XZ_SigmaX", XZ_SigmaX[energiesX1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XZ_SigmaZ", XZ_SigmaZ[energiesX1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XZ_GaussSigmaX", XZ_GaussSigmaX[energiesX1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XZ_GaussSigmaZ", XZ_GaussSigmaZ[energiesX1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XZ_LengthX", XZ_LengthX[energiesX1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XZ_VolumeX", XZ_VolumeX[energiesX1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XZ_MeanX", XZ_MeanX[energiesX1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XZ_MeanZ", XZ_MeanZ[energiesX1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XZ_SkewZ", XZ_SkewZ[energiesX1FirstKey]);
+    } else {
+        std::cerr << "Error: energiesX is empty. Some observables will not be set." << std::endl;
+    }
 
-        // --- Observables merging max tracks XZ and YZ --- //
-        SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
-        SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
-        SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
-        SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
-    */
+    if (!energiesY.empty()) {
+        int energiesY1FirstKey = energiesY[1].first;
+
+        SetObservableValue("SecondMaxTrack_YZ_NHitsY", YZ_NHitsY[energiesY1FirstKey]);
+        SetObservableValue("SecondMaxTrack_YZ_EnergyY", YZ_EnergyY[energiesY1FirstKey]);
+        SetObservableValue("SecondMaxTrack_YZ_SigmaY", YZ_SigmaY[energiesY1FirstKey]);
+        SetObservableValue("SecondMaxTrack_YZ_SigmaZ", YZ_SigmaZ[energiesY1FirstKey]);
+        SetObservableValue("SecondMaxTrack_YZ_GaussSigmaY", YZ_GaussSigmaY[energiesY1FirstKey]);
+        SetObservableValue("SecondMaxTrack_YZ_GaussSigmaZ", YZ_GaussSigmaZ[energiesY1FirstKey]);
+        SetObservableValue("SecondMaxTrack_YZ_LengthY", YZ_LengthY[energiesY1FirstKey]);
+        SetObservableValue("SecondMaxTrack_YZ_VolumeY", YZ_VolumeY[energiesY1FirstKey]);
+        SetObservableValue("SecondMaxTrack_YZ_MeanY", YZ_MeanY[energiesY1FirstKey]);
+        SetObservableValue("SecondMaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY1FirstKey]);
+        SetObservableValue("SecondMaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY1FirstKey]);
+    } else {
+        std::cerr << "Error: energiesY is empty. Some observables will not be set." << std::endl;
+    }
+/*
+    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[1]);
+    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
+    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[1]);
+    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[1]);
+
+    if (fTrackEvent->GetNumberOfTracks() > 1) {
+        SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
+                           (energiesX[1].second + energiesY[1].second) / fTrackEvent->GetEnergy());
+        SetObservableValue(
+            "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
+            (energiesX[1].second - energiesY[1].second) / (energiesX[1].second + energiesY[1].second));
+    } else {
+        SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0);
+    }
+
+    // --- Distance obsevables between first two tracks --- //
+    SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
+    SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
+    SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
+                       TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
+                                   YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
+
+    // --- Observables merging max tracks XZ and YZ --- //
+    SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
+    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
+    SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
+    SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
+*/
     return fTrackEvent;
 }
 

--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -414,9 +414,9 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance);
     SetObservableValue("Map_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance);
 
-
     // --- Max track observables --- //
-    int energiesX0FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
+    int energiesX0FirstKey =
+        -1;  // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
     Double_t energiesX0SecondKey = -1.0;
     int energiesY0FirstKey = -1;
     Double_t energiesY0SecondKey = -1.0;
@@ -464,9 +464,9 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
         SetObservableValue("MaxTrack_XZ_YZ_Energy", energiesX[0].second + energiesY[0].second);
         SetObservableValue("MaxTrack_XZ_YZ_MaxTrackEnergyPercentage",
-                        (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
+                           (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
         SetObservableValue("MaxTrack_XZ_YZ_EnergyBalanceXY", (energiesX[0].second - energiesY[0].second) /
-                                                                (energiesX[0].second + energiesY[0].second));
+                                                                 (energiesX[0].second + energiesY[0].second));
 
     } else {
         std::cerr << "Error: energiesX or energiesY is empty. Some observables will not be set." << std::endl;
@@ -478,7 +478,8 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[0]);
 
     // --- Second max track observables --- //
-    int energiesX1FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
+    int energiesX1FirstKey =
+        -1;  // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
     Double_t energiesX1SecondKey = -1.0;
     int energiesY1FirstKey = -1;
     Double_t energiesY1SecondKey = -1.0;
@@ -532,9 +533,10 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         if (fTrackEvent->GetNumberOfTracks() > 2) {
             SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX1SecondKey + energiesY1SecondKey);
             SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
-                            (energiesX1SecondKey + energiesY1SecondKey) / fTrackEvent->GetEnergy());
-            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
-                            (energiesX1SecondKey - energiesY1SecondKey) / (energiesX1SecondKey + energiesY1SecondKey));
+                               (energiesX1SecondKey + energiesY1SecondKey) / fTrackEvent->GetEnergy());
+            SetObservableValue(
+                "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
+                (energiesX1SecondKey - energiesY1SecondKey) / (energiesX1SecondKey + energiesY1SecondKey));
         } else {
             SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0.0);
             SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0.0);

--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -414,12 +414,12 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance);
     SetObservableValue("Map_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance);
 
+
     // --- Max track observables --- //
-    int energiesX0FirstKey =
-        -1;  // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
-    int energiesX0SecondKey = -1;
+    int energiesX0FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
+    Double_t energiesX0SecondKey = -1.0;
     int energiesY0FirstKey = -1;
-    int energiesY0SecondKey = -1;
+    Double_t energiesY0SecondKey = -1.0;
 
     // Copy the MaxTrack keys immediately after checking the vector
     if (!energiesX.empty()) {
@@ -459,14 +459,14 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     }
 
     if (!energiesX.empty() & !energiesY.empty()) {
-        int energiesX0SecondKey = energiesX[0].second;
-        int energiesY0SecondKey = energiesY[0].second;
+        Double_t energiesX0SecondKey = energiesX[0].second;
+        Double_t energiesY0SecondKey = energiesY[0].second;
 
         SetObservableValue("MaxTrack_XZ_YZ_Energy", energiesX[0].second + energiesY[0].second);
         SetObservableValue("MaxTrack_XZ_YZ_MaxTrackEnergyPercentage",
-                           (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
+                        (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
         SetObservableValue("MaxTrack_XZ_YZ_EnergyBalanceXY", (energiesX[0].second - energiesY[0].second) /
-                                                                 (energiesX[0].second + energiesY[0].second));
+                                                                (energiesX[0].second + energiesY[0].second));
 
     } else {
         std::cerr << "Error: energiesX or energiesY is empty. Some observables will not be set." << std::endl;
@@ -478,11 +478,10 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[0]);
 
     // --- Second max track observables --- //
-    int energiesX1FirstKey =
-        -1;  // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
-    int energiesX1SecondKey = -1;
+    int energiesX1FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
+    Double_t energiesX1SecondKey = -1.0;
     int energiesY1FirstKey = -1;
-    int energiesY1SecondKey = -1;
+    Double_t energiesY1SecondKey = -1.0;
 
     // Copy the SecondTrack keys immediately after checking the vector
     if (!energiesX.empty()) {
@@ -525,33 +524,39 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
     SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[1]);
     SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[1]);
-    /*
-        if (fTrackEvent->GetNumberOfTracks() > 1) {
-            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);
+
+    if (!energiesX.empty() & !energiesY.empty()) {
+        Double_t energiesX1SecondKey = energiesX[1].second;
+        Double_t energiesY1SecondKey = energiesY[1].second;
+
+        if (fTrackEvent->GetNumberOfTracks() > 2) {
+            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX1SecondKey + energiesY1SecondKey);
             SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
-                               (energiesX[1].second + energiesY[1].second) / fTrackEvent->GetEnergy());
-            SetObservableValue(
-                "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
-                (energiesX[1].second - energiesY[1].second) / (energiesX[1].second + energiesY[1].second));
+                            (energiesX1SecondKey + energiesY1SecondKey) / fTrackEvent->GetEnergy());
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
+                            (energiesX1SecondKey - energiesY1SecondKey) / (energiesX1SecondKey + energiesY1SecondKey));
         } else {
-            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0);
-            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0);
-            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0.0);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0.0);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0.0);
         }
+    } else {
+        std::cerr << "Error: energiesX or energiesY is empty. Some observables will not be set." << std::endl;
+    }
 
-        // --- Distance obsevables between first two tracks --- //
-        SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
-        SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
-        SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
-                           TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
-                                       YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
+    // --- Distance obsevables between first two tracks --- //
+    SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
+    SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
+    SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
+                       TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
+                                   YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
 
-        // --- Observables merging max tracks XZ and YZ --- //
-        SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
-        SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
-        SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
-        SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
-    */
+    // --- Observables merging max tracks XZ and YZ --- //
+    SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
+    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
+    SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
+    SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
+
     return fTrackEvent;
 }
 

--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -414,9 +414,9 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance);
     SetObservableValue("Map_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance);
 
+
     // --- Max track observables --- //
-    int energiesX0FirstKey =
-        -1;  // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
+    int energiesX0FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
     int energiesX0SecondKey = -1;
     int energiesY0FirstKey = -1;
     int energiesY0SecondKey = -1;
@@ -464,9 +464,9 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
         SetObservableValue("MaxTrack_XZ_YZ_Energy", energiesX[0].second + energiesY[0].second);
         SetObservableValue("MaxTrack_XZ_YZ_MaxTrackEnergyPercentage",
-                           (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
+                        (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
         SetObservableValue("MaxTrack_XZ_YZ_EnergyBalanceXY", (energiesX[0].second - energiesY[0].second) /
-                                                                 (energiesX[0].second + energiesY[0].second));
+                                                                (energiesX[0].second + energiesY[0].second));
 
     } else {
         std::cerr << "Error: energiesX or energiesY is empty. Some observables will not be set." << std::endl;
@@ -478,8 +478,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[0]);
 
     // --- Second max track observables --- //
-    int energiesX1FirstKey =
-        -1;  // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
+    int energiesX1FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
     int energiesX1SecondKey = -1;
     int energiesY1FirstKey = -1;
     int energiesY1SecondKey = -1;
@@ -520,38 +519,38 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     } else {
         std::cerr << "Error: energiesY is empty. Some observables will not be set." << std::endl;
     }
-    /*
-        SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[1]);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[1]);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[1]);
 
-        if (fTrackEvent->GetNumberOfTracks() > 1) {
-            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);
-            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
-                               (energiesX[1].second + energiesY[1].second) / fTrackEvent->GetEnergy());
-            SetObservableValue(
-                "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
-                (energiesX[1].second - energiesY[1].second) / (energiesX[1].second + energiesY[1].second));
-        } else {
-            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0);
-            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0);
-            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0);
-        }
+    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[1]);
+    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
+    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[1]);
+    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[1]);
+/*
+    if (fTrackEvent->GetNumberOfTracks() > 1) {
+        SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
+                           (energiesX[1].second + energiesY[1].second) / fTrackEvent->GetEnergy());
+        SetObservableValue(
+            "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
+            (energiesX[1].second - energiesY[1].second) / (energiesX[1].second + energiesY[1].second));
+    } else {
+        SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0);
+    }
 
-        // --- Distance obsevables between first two tracks --- //
-        SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
-        SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
-        SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
-                           TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
-                                       YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
+    // --- Distance obsevables between first two tracks --- //
+    SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
+    SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
+    SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
+                       TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
+                                   YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
 
-        // --- Observables merging max tracks XZ and YZ --- //
-        SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
-        SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
-        SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
-        SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
-    */
+    // --- Observables merging max tracks XZ and YZ --- //
+    SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
+    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
+    SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
+    SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
+*/
     return fTrackEvent;
 }
 

--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -415,15 +415,10 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance);
 
     // --- Max track observables --- //
-    int energiesX0FirstKey =
-        -1;  // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
-    Double_t energiesX0SecondKey = -1.0;
-    int energiesY0FirstKey = -1;
-    Double_t energiesY0SecondKey = -1.0;
 
     // Copy the MaxTrack keys immediately after checking the vector
     if (!energiesX.empty()) {
-        int energiesX0FirstKey = energiesX[0].first;
+        int energiesX0FirstKey = energiesX[0].first;    // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
 
         SetObservableValue("MaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX0FirstKey]);
         SetObservableValue("MaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX0FirstKey]);
@@ -462,11 +457,11 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         Double_t energiesX0SecondKey = energiesX[0].second;
         Double_t energiesY0SecondKey = energiesY[0].second;
 
-        SetObservableValue("MaxTrack_XZ_YZ_Energy", energiesX[0].second + energiesY[0].second);
+        SetObservableValue("MaxTrack_XZ_YZ_Energy", energiesX0SecondKey + energiesY0SecondKey);
         SetObservableValue("MaxTrack_XZ_YZ_MaxTrackEnergyPercentage",
-                           (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
-        SetObservableValue("MaxTrack_XZ_YZ_EnergyBalanceXY", (energiesX[0].second - energiesY[0].second) /
-                                                                 (energiesX[0].second + energiesY[0].second));
+                           (energiesX0SecondKey + energiesY0SecondKey) / fTrackEvent->GetEnergy());
+        SetObservableValue("MaxTrack_XZ_YZ_EnergyBalanceXY", (energiesX0SecondKey - energiesY0SecondKey) /
+                                                                 (energiesX0SecondKey + energiesY0SecondKey));
 
     } else {
         std::cerr << "Error: energiesX or energiesY is empty. Some observables will not be set." << std::endl;
@@ -478,15 +473,10 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[0]);
 
     // --- Second max track observables --- //
-    int energiesX1FirstKey =
-        -1;  // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
-    Double_t energiesX1SecondKey = -1.0;
-    int energiesY1FirstKey = -1;
-    Double_t energiesY1SecondKey = -1.0;
 
     // Copy the SecondTrack keys immediately after checking the vector
     if (!energiesX.empty()) {
-        int energiesX1FirstKey = energiesX[1].first;
+        int energiesX1FirstKey = energiesX[1].first;    // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
 
         SetObservableValue("SecondMaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX1FirstKey]);
         SetObservableValue("SecondMaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX1FirstKey]);

--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -415,6 +415,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance);
 
     // --- Max track observables --- //
+/*
     SetObservableValue("MaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX[0].first]);
     SetObservableValue("MaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX[0].first]);
     SetObservableValue("MaxTrack_XZ_SigmaX", XZ_SigmaX[energiesX[0].first]);
@@ -505,7 +506,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
     SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
     SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
-
+*/
     return fTrackEvent;
 }
 

--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -415,98 +415,98 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance);
 
     // --- Max track observables --- //
-/*
-    SetObservableValue("MaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX[0].first]);
-    SetObservableValue("MaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX[0].first]);
-    SetObservableValue("MaxTrack_XZ_SigmaX", XZ_SigmaX[energiesX[0].first]);
-    SetObservableValue("MaxTrack_XZ_SigmaZ", XZ_SigmaZ[energiesX[0].first]);
-    SetObservableValue("MaxTrack_XZ_GaussSigmaX", XZ_GaussSigmaX[energiesX[0].first]);
-    SetObservableValue("MaxTrack_XZ_GaussSigmaZ", XZ_GaussSigmaZ[energiesX[0].first]);
-    SetObservableValue("MaxTrack_XZ_LengthX", XZ_LengthX[energiesX[0].first]);
-    SetObservableValue("MaxTrack_XZ_VolumeX", XZ_VolumeX[energiesX[0].first]);
-    SetObservableValue("MaxTrack_XZ_MeanX", XZ_MeanX[energiesX[0].first]);
-    SetObservableValue("MaxTrack_XZ_MeanZ", XZ_MeanZ[energiesX[0].first]);
-    SetObservableValue("MaxTrack_XZ_SkewZ", XZ_SkewZ[energiesX[0].first]);
+    /*
+        SetObservableValue("MaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX[0].first]);
+        SetObservableValue("MaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX[0].first]);
+        SetObservableValue("MaxTrack_XZ_SigmaX", XZ_SigmaX[energiesX[0].first]);
+        SetObservableValue("MaxTrack_XZ_SigmaZ", XZ_SigmaZ[energiesX[0].first]);
+        SetObservableValue("MaxTrack_XZ_GaussSigmaX", XZ_GaussSigmaX[energiesX[0].first]);
+        SetObservableValue("MaxTrack_XZ_GaussSigmaZ", XZ_GaussSigmaZ[energiesX[0].first]);
+        SetObservableValue("MaxTrack_XZ_LengthX", XZ_LengthX[energiesX[0].first]);
+        SetObservableValue("MaxTrack_XZ_VolumeX", XZ_VolumeX[energiesX[0].first]);
+        SetObservableValue("MaxTrack_XZ_MeanX", XZ_MeanX[energiesX[0].first]);
+        SetObservableValue("MaxTrack_XZ_MeanZ", XZ_MeanZ[energiesX[0].first]);
+        SetObservableValue("MaxTrack_XZ_SkewZ", XZ_SkewZ[energiesX[0].first]);
 
-    SetObservableValue("MaxTrack_YZ_NHitsY", YZ_NHitsY[energiesY[0].first]);
-    SetObservableValue("MaxTrack_YZ_EnergyY", YZ_EnergyY[energiesY[0].first]);
-    SetObservableValue("MaxTrack_YZ_SigmaY", YZ_SigmaY[energiesY[0].first]);
-    SetObservableValue("MaxTrack_YZ_SigmaZ", YZ_SigmaZ[energiesY[0].first]);
-    SetObservableValue("MaxTrack_YZ_GaussSigmaY", YZ_GaussSigmaY[energiesY[0].first]);
-    SetObservableValue("MaxTrack_YZ_GaussSigmaZ", YZ_GaussSigmaZ[energiesY[0].first]);
-    SetObservableValue("MaxTrack_YZ_LengthY", YZ_LengthY[energiesY[0].first]);
-    SetObservableValue("MaxTrack_YZ_VolumeY", YZ_VolumeY[energiesY[0].first]);
-    SetObservableValue("MaxTrack_YZ_MeanY", YZ_MeanY[energiesY[0].first]);
-    SetObservableValue("MaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY[0].first]);
-    SetObservableValue("MaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY[0].first]);
+        SetObservableValue("MaxTrack_YZ_NHitsY", YZ_NHitsY[energiesY[0].first]);
+        SetObservableValue("MaxTrack_YZ_EnergyY", YZ_EnergyY[energiesY[0].first]);
+        SetObservableValue("MaxTrack_YZ_SigmaY", YZ_SigmaY[energiesY[0].first]);
+        SetObservableValue("MaxTrack_YZ_SigmaZ", YZ_SigmaZ[energiesY[0].first]);
+        SetObservableValue("MaxTrack_YZ_GaussSigmaY", YZ_GaussSigmaY[energiesY[0].first]);
+        SetObservableValue("MaxTrack_YZ_GaussSigmaZ", YZ_GaussSigmaZ[energiesY[0].first]);
+        SetObservableValue("MaxTrack_YZ_LengthY", YZ_LengthY[energiesY[0].first]);
+        SetObservableValue("MaxTrack_YZ_VolumeY", YZ_VolumeY[energiesY[0].first]);
+        SetObservableValue("MaxTrack_YZ_MeanY", YZ_MeanY[energiesY[0].first]);
+        SetObservableValue("MaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY[0].first]);
+        SetObservableValue("MaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY[0].first]);
 
-    SetObservableValue("MaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[0]);
-    SetObservableValue("MaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[0]);
-    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[0]);
-    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[0]);
+        SetObservableValue("MaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[0]);
+        SetObservableValue("MaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[0]);
+        SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[0]);
+        SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[0]);
 
-    SetObservableValue("MaxTrack_XZ_YZ_Energy", energiesX[0].second + energiesY[0].second);
-    SetObservableValue("MaxTrack_XZ_YZ_MaxTrackEnergyPercentage",
-                       (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
-    SetObservableValue("MaxTrack_XZ_YZ_EnergyBalanceXY", (energiesX[0].second - energiesY[0].second) /
-                                                             (energiesX[0].second + energiesY[0].second));
+        SetObservableValue("MaxTrack_XZ_YZ_Energy", energiesX[0].second + energiesY[0].second);
+        SetObservableValue("MaxTrack_XZ_YZ_MaxTrackEnergyPercentage",
+                           (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
+        SetObservableValue("MaxTrack_XZ_YZ_EnergyBalanceXY", (energiesX[0].second - energiesY[0].second) /
+                                                                 (energiesX[0].second + energiesY[0].second));
 
-    // --- Second max track observables --- //
-    SetObservableValue("SecondMaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX[1].first]);
-    SetObservableValue("SecondMaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX[1].first]);
-    SetObservableValue("SecondMaxTrack_XZ_SigmaX", XZ_SigmaX[energiesX[1].first]);
-    SetObservableValue("SecondMaxTrack_XZ_SigmaZ", XZ_SigmaZ[energiesX[1].first]);
-    SetObservableValue("SecondMaxTrack_XZ_GaussSigmaX", XZ_GaussSigmaX[energiesX[1].first]);
-    SetObservableValue("SecondMaxTrack_XZ_GaussSigmaZ", XZ_GaussSigmaZ[energiesX[1].first]);
-    SetObservableValue("SecondMaxTrack_XZ_LengthX", XZ_LengthX[energiesX[1].first]);
-    SetObservableValue("SecondMaxTrack_XZ_VolumeX", XZ_VolumeX[energiesX[1].first]);
-    SetObservableValue("SecondMaxTrack_XZ_MeanX", XZ_MeanX[energiesX[1].first]);
-    SetObservableValue("SecondMaxTrack_XZ_MeanZ", XZ_MeanZ[energiesX[1].first]);
-    SetObservableValue("SecondMaxTrack_XZ_SkewZ", XZ_SkewZ[energiesX[1].first]);
+        // --- Second max track observables --- //
+        SetObservableValue("SecondMaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX[1].first]);
+        SetObservableValue("SecondMaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX[1].first]);
+        SetObservableValue("SecondMaxTrack_XZ_SigmaX", XZ_SigmaX[energiesX[1].first]);
+        SetObservableValue("SecondMaxTrack_XZ_SigmaZ", XZ_SigmaZ[energiesX[1].first]);
+        SetObservableValue("SecondMaxTrack_XZ_GaussSigmaX", XZ_GaussSigmaX[energiesX[1].first]);
+        SetObservableValue("SecondMaxTrack_XZ_GaussSigmaZ", XZ_GaussSigmaZ[energiesX[1].first]);
+        SetObservableValue("SecondMaxTrack_XZ_LengthX", XZ_LengthX[energiesX[1].first]);
+        SetObservableValue("SecondMaxTrack_XZ_VolumeX", XZ_VolumeX[energiesX[1].first]);
+        SetObservableValue("SecondMaxTrack_XZ_MeanX", XZ_MeanX[energiesX[1].first]);
+        SetObservableValue("SecondMaxTrack_XZ_MeanZ", XZ_MeanZ[energiesX[1].first]);
+        SetObservableValue("SecondMaxTrack_XZ_SkewZ", XZ_SkewZ[energiesX[1].first]);
 
-    SetObservableValue("SecondMaxTrack_YZ_NHitsY", YZ_NHitsY[energiesY[1].first]);
-    SetObservableValue("SecondMaxTrack_YZ_EnergyY", YZ_EnergyY[energiesY[1].first]);
-    SetObservableValue("SecondMaxTrack_YZ_SigmaY", YZ_SigmaY[energiesY[1].first]);
-    SetObservableValue("SecondMaxTrack_YZ_SigmaZ", YZ_SigmaZ[energiesY[1].first]);
-    SetObservableValue("SecondMaxTrack_YZ_GaussSigmaY", YZ_GaussSigmaY[energiesY[1].first]);
-    SetObservableValue("SecondMaxTrack_YZ_GaussSigmaZ", YZ_GaussSigmaZ[energiesY[1].first]);
-    SetObservableValue("SecondMaxTrack_YZ_LengthY", YZ_LengthY[energiesY[1].first]);
-    SetObservableValue("SecondMaxTrack_YZ_VolumeY", YZ_VolumeY[energiesY[1].first]);
-    SetObservableValue("SecondMaxTrack_YZ_MeanY", YZ_MeanY[energiesY[1].first]);
-    SetObservableValue("SecondMaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY[1].first]);
-    SetObservableValue("SecondMaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY[1].first]);
+        SetObservableValue("SecondMaxTrack_YZ_NHitsY", YZ_NHitsY[energiesY[1].first]);
+        SetObservableValue("SecondMaxTrack_YZ_EnergyY", YZ_EnergyY[energiesY[1].first]);
+        SetObservableValue("SecondMaxTrack_YZ_SigmaY", YZ_SigmaY[energiesY[1].first]);
+        SetObservableValue("SecondMaxTrack_YZ_SigmaZ", YZ_SigmaZ[energiesY[1].first]);
+        SetObservableValue("SecondMaxTrack_YZ_GaussSigmaY", YZ_GaussSigmaY[energiesY[1].first]);
+        SetObservableValue("SecondMaxTrack_YZ_GaussSigmaZ", YZ_GaussSigmaZ[energiesY[1].first]);
+        SetObservableValue("SecondMaxTrack_YZ_LengthY", YZ_LengthY[energiesY[1].first]);
+        SetObservableValue("SecondMaxTrack_YZ_VolumeY", YZ_VolumeY[energiesY[1].first]);
+        SetObservableValue("SecondMaxTrack_YZ_MeanY", YZ_MeanY[energiesY[1].first]);
+        SetObservableValue("SecondMaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY[1].first]);
+        SetObservableValue("SecondMaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY[1].first]);
 
-    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[1]);
-    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
-    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[1]);
-    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[1]);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[1]);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[1]);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[1]);
 
-    if (fTrackEvent->GetNumberOfTracks() > 1) {
-        SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
-                           (energiesX[1].second + energiesY[1].second) / fTrackEvent->GetEnergy());
-        SetObservableValue(
-            "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
-            (energiesX[1].second - energiesY[1].second) / (energiesX[1].second + energiesY[1].second));
-    } else {
-        SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0);
-    }
+        if (fTrackEvent->GetNumberOfTracks() > 1) {
+            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
+                               (energiesX[1].second + energiesY[1].second) / fTrackEvent->GetEnergy());
+            SetObservableValue(
+                "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
+                (energiesX[1].second - energiesY[1].second) / (energiesX[1].second + energiesY[1].second));
+        } else {
+            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0);
+        }
 
-    // --- Distance obsevables between first two tracks --- //
-    SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
-    SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
-    SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
-                       TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
-                                   YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
+        // --- Distance obsevables between first two tracks --- //
+        SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
+        SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
+        SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
+                           TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
+                                       YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
 
-    // --- Observables merging max tracks XZ and YZ --- //
-    SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
-    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
-    SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
-    SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
-*/
+        // --- Observables merging max tracks XZ and YZ --- //
+        SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
+        SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
+        SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
+        SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
+    */
     return fTrackEvent;
 }
 

--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -433,7 +433,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         SetObservableValue("MaxTrack_XZ_MeanZ", XZ_MeanZ[energiesX0FirstKey]);
         SetObservableValue("MaxTrack_XZ_SkewZ", XZ_SkewZ[energiesX0FirstKey]);
     } else {
-        std::cerr << "Error: energiesX is empty. Some observables will not be set." << std::endl;
+        std::cerr << "Error: energiesX is empty. The observables are set to 0." << std::endl;
     }
 
     if (!energiesY.empty()) {
@@ -451,7 +451,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         SetObservableValue("MaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY0FirstKey]);
         SetObservableValue("MaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY0FirstKey]);
     } else {
-        std::cerr << "Error: energiesY is empty. Some observables will not be set." << std::endl;
+        std::cerr << "Error: energiesY is empty. The observables are set to 0." << std::endl;
     }
 
     if (!energiesX.empty() & !energiesY.empty()) {
@@ -465,7 +465,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
                                                                  (energiesX0SecondKey + energiesY0SecondKey));
 
     } else {
-        std::cerr << "Error: energiesX or energiesY is empty. Some observables will not be set." << std::endl;
+        std::cerr << "Error: energiesX or energiesY is empty. The observables are set to 0." << std::endl;
     }
 
     SetObservableValue("MaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[0]);
@@ -492,7 +492,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         SetObservableValue("SecondMaxTrack_XZ_MeanZ", XZ_MeanZ[energiesX1FirstKey]);
         SetObservableValue("SecondMaxTrack_XZ_SkewZ", XZ_SkewZ[energiesX1FirstKey]);
     } else {
-        std::cerr << "Error: energiesX is empty. Some observables will not be set." << std::endl;
+        std::cerr << "Error: energiesX is empty. The observables are set to 0." << std::endl;
     }
 
     if (!energiesY.empty()) {
@@ -510,7 +510,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         SetObservableValue("SecondMaxTrack_YZ_MeanZ", YZ_MeanZ[energiesY1FirstKey]);
         SetObservableValue("SecondMaxTrack_YZ_SkewZ", YZ_SkewZ[energiesY1FirstKey]);
     } else {
-        std::cerr << "Error: energiesY is empty. Some observables will not be set." << std::endl;
+        std::cerr << "Error: energiesY is empty. The observables are set to 0." << std::endl;
     }
 
     SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[1]);
@@ -535,7 +535,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
             SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0.0);
         }
     } else {
-        std::cerr << "Error: energiesX or energiesY is empty. Some observables will not be set." << std::endl;
+        std::cerr << "Error: energiesX or energiesY is empty. The observables are set to 0." << std::endl;
     }
 
     // --- Distance obsevables between first two tracks --- //

--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -418,7 +418,8 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     // Copy the MaxTrack keys immediately after checking the vector
     if (!energiesX.empty()) {
-        int energiesX0FirstKey = energiesX[0].first;    // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
+        int energiesX0FirstKey =
+            energiesX[0].first;  // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
 
         SetObservableValue("MaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX0FirstKey]);
         SetObservableValue("MaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX0FirstKey]);
@@ -476,7 +477,8 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     // Copy the SecondTrack keys immediately after checking the vector
     if (!energiesX.empty()) {
-        int energiesX1FirstKey = energiesX[1].first;    // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
+        int energiesX1FirstKey =
+            energiesX[1].first;  // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
 
         SetObservableValue("SecondMaxTrack_XZ_NHitsX", XZ_NHitsX[energiesX1FirstKey]);
         SetObservableValue("SecondMaxTrack_XZ_EnergyX", XZ_EnergyX[energiesX1FirstKey]);

--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -414,9 +414,9 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance);
     SetObservableValue("Map_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance);
 
-
     // --- Max track observables --- //
-    int energiesX0FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
+    int energiesX0FirstKey =
+        -1;  // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
     int energiesX0SecondKey = -1;
     int energiesY0FirstKey = -1;
     int energiesY0SecondKey = -1;
@@ -464,9 +464,9 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
         SetObservableValue("MaxTrack_XZ_YZ_Energy", energiesX[0].second + energiesY[0].second);
         SetObservableValue("MaxTrack_XZ_YZ_MaxTrackEnergyPercentage",
-                        (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
+                           (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
         SetObservableValue("MaxTrack_XZ_YZ_EnergyBalanceXY", (energiesX[0].second - energiesY[0].second) /
-                                                                (energiesX[0].second + energiesY[0].second));
+                                                                 (energiesX[0].second + energiesY[0].second));
 
     } else {
         std::cerr << "Error: energiesX or energiesY is empty. Some observables will not be set." << std::endl;
@@ -478,7 +478,8 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[0]);
 
     // --- Second max track observables --- //
-    int energiesX1FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
+    int energiesX1FirstKey =
+        -1;  // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
     int energiesX1SecondKey = -1;
     int energiesY1FirstKey = -1;
     int energiesY1SecondKey = -1;
@@ -519,38 +520,38 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     } else {
         std::cerr << "Error: energiesY is empty. Some observables will not be set." << std::endl;
     }
-/*
-    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[1]);
-    SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
-    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[1]);
-    SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[1]);
+    /*
+        SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaXYBalance", XZ_YZ_SigmaXYBalance[1]);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[1]);
+        SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[1]);
 
-    if (fTrackEvent->GetNumberOfTracks() > 1) {
-        SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
-                           (energiesX[1].second + energiesY[1].second) / fTrackEvent->GetEnergy());
-        SetObservableValue(
-            "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
-            (energiesX[1].second - energiesY[1].second) / (energiesX[1].second + energiesY[1].second));
-    } else {
-        SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0);
-    }
+        if (fTrackEvent->GetNumberOfTracks() > 1) {
+            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
+                               (energiesX[1].second + energiesY[1].second) / fTrackEvent->GetEnergy());
+            SetObservableValue(
+                "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
+                (energiesX[1].second - energiesY[1].second) / (energiesX[1].second + energiesY[1].second));
+        } else {
+            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0);
+        }
 
-    // --- Distance obsevables between first two tracks --- //
-    SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
-    SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
-    SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
-                       TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
-                                   YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
+        // --- Distance obsevables between first two tracks --- //
+        SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
+        SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
+        SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
+                           TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
+                                       YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
 
-    // --- Observables merging max tracks XZ and YZ --- //
-    SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
-    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
-    SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
-    SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
-*/
+        // --- Observables merging max tracks XZ and YZ --- //
+        SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
+        SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
+        SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
+        SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
+    */
     return fTrackEvent;
 }
 

--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -414,9 +414,9 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance);
     SetObservableValue("Map_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance);
 
-
     // --- Max track observables --- //
-    int energiesX0FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
+    int energiesX0FirstKey =
+        -1;  // Declare Keys outside to avoid error when accessing "energiesX[0].first"...
     int energiesX0SecondKey = -1;
     int energiesY0FirstKey = -1;
     int energiesY0SecondKey = -1;
@@ -464,9 +464,9 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
         SetObservableValue("MaxTrack_XZ_YZ_Energy", energiesX[0].second + energiesY[0].second);
         SetObservableValue("MaxTrack_XZ_YZ_MaxTrackEnergyPercentage",
-                        (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
+                           (energiesX[0].second + energiesY[0].second) / fTrackEvent->GetEnergy());
         SetObservableValue("MaxTrack_XZ_YZ_EnergyBalanceXY", (energiesX[0].second - energiesY[0].second) /
-                                                                (energiesX[0].second + energiesY[0].second));
+                                                                 (energiesX[0].second + energiesY[0].second));
 
     } else {
         std::cerr << "Error: energiesX or energiesY is empty. Some observables will not be set." << std::endl;
@@ -478,7 +478,8 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[0]);
 
     // --- Second max track observables --- //
-    int energiesX1FirstKey = -1; // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
+    int energiesX1FirstKey =
+        -1;  // Declare Keys outside to avoid error when accessing "energiesX[1].first"...
     int energiesX1SecondKey = -1;
     int energiesY1FirstKey = -1;
     int energiesY1SecondKey = -1;
@@ -524,33 +525,33 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("SecondMaxTrack_XZ_YZ_SigmaZBalance", XZ_YZ_SigmaZBalance[1]);
     SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaXYBalance", XZ_YZ_GaussSigmaXYBalance[1]);
     SetObservableValue("SecondMaxTrack_XZ_YZ_GaussSigmaZBalance", XZ_YZ_GaussSigmaZBalance[1]);
-/*
-    if (fTrackEvent->GetNumberOfTracks() > 1) {
-        SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
-                           (energiesX[1].second + energiesY[1].second) / fTrackEvent->GetEnergy());
-        SetObservableValue(
-            "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
-            (energiesX[1].second - energiesY[1].second) / (energiesX[1].second + energiesY[1].second));
-    } else {
-        SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0);
-        SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0);
-    }
+    /*
+        if (fTrackEvent->GetNumberOfTracks() > 1) {
+            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", energiesX[1].second + energiesY[1].second);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage",
+                               (energiesX[1].second + energiesY[1].second) / fTrackEvent->GetEnergy());
+            SetObservableValue(
+                "SecondMaxTrack_XZ_YZ_EnergyBalanceXY",
+                (energiesX[1].second - energiesY[1].second) / (energiesX[1].second + energiesY[1].second));
+        } else {
+            SetObservableValue("SecondMaxTrack_XZ_YZ_Energy", 0);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyPercentage", 0);
+            SetObservableValue("SecondMaxTrack_XZ_YZ_EnergyBalanceXY", 0);
+        }
 
-    // --- Distance obsevables between first two tracks --- //
-    SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
-    SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
-    SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
-                       TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
-                                   YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
+        // --- Distance obsevables between first two tracks --- //
+        SetObservableValue("XZ_FirstSecondTracksDistanceXZ", XZ_FirstSecondTracksDistanceXZ);
+        SetObservableValue("YZ_FirstSecondTracksDistanceYZ", YZ_FirstSecondTracksDistanceYZ);
+        SetObservableValue("XZ_YZ_FirstSecondTracksDistanceSum",
+                           TMath::Sqrt(XZ_FirstSecondTracksDistanceXZ * XZ_FirstSecondTracksDistanceXZ +
+                                       YZ_FirstSecondTracksDistanceYZ * YZ_FirstSecondTracksDistanceYZ));
 
-    // --- Observables merging max tracks XZ and YZ --- //
-    SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
-    SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
-    SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
-    SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
-*/
+        // --- Observables merging max tracks XZ and YZ --- //
+        SetObservableValue("MaxTrack_XZ_YZ_SigmaZ", MaxTrack_XZ_YZ_SigmaZ);
+        SetObservableValue("MaxTrack_XZ_YZ_GaussSigmaZ", MaxTrack_XZ_YZ_GaussSigmaZ);
+        SetObservableValue("MaxTrack_XZ_YZ_SkewXY", MaxTrack_XZ_YZ_SkewXY);
+        SetObservableValue("MaxTrack_XZ_YZ_SkewZ", MaxTrack_XZ_YZ_SkewZ);
+    */
     return fTrackEvent;
 }
 

--- a/src/TRestTrack3DAnalysisProcess.cxx
+++ b/src/TRestTrack3DAnalysisProcess.cxx
@@ -241,15 +241,14 @@ TRestEvent* TRestTrack3DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XYZ_SkewXY", XYZ_SkewXY);
     SetObservableValue("Map_XYZ_SkewZ", XYZ_SkewZ);
 
-    int energies0FirstKey = -1; // Declare Keys outside to avoid error when accessing "energies[0].first"...
+    int energies0FirstKey = -1;  // Declare Keys outside to avoid error when accessing "energies[0].first"...
     Double_t energies0SecondKey = -1.0;
 
-    int energies1FirstKey = -1; // Declare Keys outside to avoid error when accessing "energies[1].first"...
+    int energies1FirstKey = -1;  // Declare Keys outside to avoid error when accessing "energies[1].first"...
     Double_t energies1SecondKey = -1.0;
 
     // Copy the MaxTrack keys immediately after checking the vector
     if (!energies.empty()) {
-
         // --- Max track observables --- //
         int energies0FirstKey = energies[0].first;
         Double_t energies0SecondKey = energies[0].second;
@@ -271,7 +270,7 @@ TRestEvent* TRestTrack3DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         SetObservableValue("MaxTrack_XYZ_SkewZ", XYZ_SkewZ[energies0FirstKey]);
 
         SetObservableValue("MaxTrack_XYZ_MaxTrackEnergyPercentage",
-                       (energies0SecondKey) / fTrackEvent->GetEnergy());
+                           (energies0SecondKey) / fTrackEvent->GetEnergy());
 
         // --- Second max track observables --- //
         int energies1FirstKey = energies[1].first;
@@ -296,7 +295,7 @@ TRestEvent* TRestTrack3DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
         if (fTrackEvent->GetNumberOfTracks() > 2) {
             SetObservableValue("SecondMaxTrack_XYZ_MaxTrackEnergyPercentage",
-                            (energies1SecondKey) / fTrackEvent->GetEnergy());
+                               (energies1SecondKey) / fTrackEvent->GetEnergy());
         } else {
             SetObservableValue("SecondMaxTrack_XYZ_MaxTrackEnergyPercentage", 0.0);
         }

--- a/src/TRestTrack3DAnalysisProcess.cxx
+++ b/src/TRestTrack3DAnalysisProcess.cxx
@@ -243,9 +243,9 @@ TRestEvent* TRestTrack3DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     // Copy the MaxTrack keys immediately after checking the vector
     if (!energies.empty()) {
-
         // --- Max track observables --- //
-        int energies0FirstKey = energies[0].first;  // Declare Keys outside to avoid error when accessing "energies[0].first"...
+        int energies0FirstKey =
+            energies[0].first;  // Declare Keys outside to avoid error when accessing "energies[0].first"...
         Double_t energies0SecondKey = energies[0].second;
 
         SetObservableValue("MaxTrack_XYZ_NHits", XYZ_NHits[energies0FirstKey]);
@@ -265,7 +265,7 @@ TRestEvent* TRestTrack3DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         SetObservableValue("MaxTrack_XYZ_SkewZ", XYZ_SkewZ[energies0FirstKey]);
 
         SetObservableValue("MaxTrack_XYZ_MaxTrackEnergyPercentage",
-                       (energies0SecondKey) / fTrackEvent->GetEnergy());
+                           (energies0SecondKey) / fTrackEvent->GetEnergy());
 
         // --- Second max track observables --- //
         int energies1FirstKey = energies[1].first;
@@ -290,7 +290,7 @@ TRestEvent* TRestTrack3DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
         if (fTrackEvent->GetNumberOfTracks() > 2) {
             SetObservableValue("SecondMaxTrack_XYZ_MaxTrackEnergyPercentage",
-                            (energies1SecondKey) / fTrackEvent->GetEnergy());
+                               (energies1SecondKey) / fTrackEvent->GetEnergy());
         } else {
             SetObservableValue("SecondMaxTrack_XYZ_MaxTrackEnergyPercentage", 0.0);
         }

--- a/src/TRestTrack3DAnalysisProcess.cxx
+++ b/src/TRestTrack3DAnalysisProcess.cxx
@@ -241,16 +241,11 @@ TRestEvent* TRestTrack3DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XYZ_SkewXY", XYZ_SkewXY);
     SetObservableValue("Map_XYZ_SkewZ", XYZ_SkewZ);
 
-    int energies0FirstKey = -1;  // Declare Keys outside to avoid error when accessing "energies[0].first"...
-    Double_t energies0SecondKey = -1.0;
-
-    int energies1FirstKey = -1;  // Declare Keys outside to avoid error when accessing "energies[1].first"...
-    Double_t energies1SecondKey = -1.0;
-
     // Copy the MaxTrack keys immediately after checking the vector
     if (!energies.empty()) {
+
         // --- Max track observables --- //
-        int energies0FirstKey = energies[0].first;
+        int energies0FirstKey = energies[0].first;  // Declare Keys outside to avoid error when accessing "energies[0].first"...
         Double_t energies0SecondKey = energies[0].second;
 
         SetObservableValue("MaxTrack_XYZ_NHits", XYZ_NHits[energies0FirstKey]);
@@ -270,7 +265,7 @@ TRestEvent* TRestTrack3DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         SetObservableValue("MaxTrack_XYZ_SkewZ", XYZ_SkewZ[energies0FirstKey]);
 
         SetObservableValue("MaxTrack_XYZ_MaxTrackEnergyPercentage",
-                           (energies0SecondKey) / fTrackEvent->GetEnergy());
+                       (energies0SecondKey) / fTrackEvent->GetEnergy());
 
         // --- Second max track observables --- //
         int energies1FirstKey = energies[1].first;
@@ -295,7 +290,7 @@ TRestEvent* TRestTrack3DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
         if (fTrackEvent->GetNumberOfTracks() > 2) {
             SetObservableValue("SecondMaxTrack_XYZ_MaxTrackEnergyPercentage",
-                               (energies1SecondKey) / fTrackEvent->GetEnergy());
+                            (energies1SecondKey) / fTrackEvent->GetEnergy());
         } else {
             SetObservableValue("SecondMaxTrack_XYZ_MaxTrackEnergyPercentage", 0.0);
         }

--- a/src/TRestTrack3DAnalysisProcess.cxx
+++ b/src/TRestTrack3DAnalysisProcess.cxx
@@ -241,48 +241,67 @@ TRestEvent* TRestTrack3DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("Map_XYZ_SkewXY", XYZ_SkewXY);
     SetObservableValue("Map_XYZ_SkewZ", XYZ_SkewZ);
 
-    // --- Max track observables --- //
-    SetObservableValue("MaxTrack_XYZ_NHits", XYZ_NHits[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_Energy", XYZ_Energy[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_SigmaX", XYZ_SigmaX[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_SigmaY", XYZ_SigmaY[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_SigmaZ", XYZ_SigmaZ[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_GaussSigmaX", XYZ_GaussSigmaX[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_GaussSigmaY", XYZ_GaussSigmaY[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_GaussSigmaZ", XYZ_GaussSigmaZ[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_Length", XYZ_Length[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_Volume", XYZ_Volume[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_MeanX", XYZ_MeanX[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_MeanY", XYZ_MeanY[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_MeanZ", XYZ_MeanZ[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_SkewZ", XYZ_SkewXY[energies[0].first]);
-    SetObservableValue("MaxTrack_XYZ_SkewZ", XYZ_SkewZ[energies[0].first]);
+    int energies0FirstKey = -1; // Declare Keys outside to avoid error when accessing "energies[0].first"...
+    Double_t energies0SecondKey = -1.0;
 
-    SetObservableValue("MaxTrack_XYZ_MaxTrackEnergyPercentage",
-                       (energies[0].second) / fTrackEvent->GetEnergy());
+    int energies1FirstKey = -1; // Declare Keys outside to avoid error when accessing "energies[1].first"...
+    Double_t energies1SecondKey = -1.0;
 
-    // --- Second max track observables --- //
-    SetObservableValue("SecondMaxTrack_XYZ_NHits", XYZ_NHits[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_Energy", XYZ_Energy[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_SigmaX", XYZ_SigmaX[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_SigmaY", XYZ_SigmaY[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_SigmaZ", XYZ_SigmaZ[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_GaussSigmaX", XYZ_GaussSigmaX[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_GaussSigmaY", XYZ_GaussSigmaY[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_GaussSigmaZ", XYZ_GaussSigmaZ[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_Length", XYZ_Length[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_Volume", XYZ_Volume[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_MeanX", XYZ_MeanX[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_MeanY", XYZ_MeanY[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_MeanZ", XYZ_MeanZ[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_SkewZ", XYZ_SkewXY[energies[1].first]);
-    SetObservableValue("SecondMaxTrack_XYZ_SkewZ", XYZ_SkewZ[energies[1].first]);
+    // Copy the MaxTrack keys immediately after checking the vector
+    if (!energies.empty()) {
 
-    if (fTrackEvent->GetNumberOfTracks() > 1) {
-        SetObservableValue("SecondMaxTrack_XYZ_MaxTrackEnergyPercentage",
-                           (energies[1].second) / fTrackEvent->GetEnergy());
+        // --- Max track observables --- //
+        int energies0FirstKey = energies[0].first;
+        Double_t energies0SecondKey = energies[0].second;
+
+        SetObservableValue("MaxTrack_XYZ_NHits", XYZ_NHits[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_Energy", XYZ_Energy[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_SigmaX", XYZ_SigmaX[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_SigmaY", XYZ_SigmaY[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_SigmaZ", XYZ_SigmaZ[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_GaussSigmaX", XYZ_GaussSigmaX[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_GaussSigmaY", XYZ_GaussSigmaY[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_GaussSigmaZ", XYZ_GaussSigmaZ[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_Length", XYZ_Length[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_Volume", XYZ_Volume[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_MeanX", XYZ_MeanX[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_MeanY", XYZ_MeanY[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_MeanZ", XYZ_MeanZ[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_SkewZ", XYZ_SkewXY[energies0FirstKey]);
+        SetObservableValue("MaxTrack_XYZ_SkewZ", XYZ_SkewZ[energies0FirstKey]);
+
+        SetObservableValue("MaxTrack_XYZ_MaxTrackEnergyPercentage",
+                       (energies0SecondKey) / fTrackEvent->GetEnergy());
+
+        // --- Second max track observables --- //
+        int energies1FirstKey = energies[1].first;
+
+        SetObservableValue("SecondMaxTrack_XYZ_NHits", XYZ_NHits[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_Energy", XYZ_Energy[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_SigmaX", XYZ_SigmaX[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_SigmaY", XYZ_SigmaY[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_SigmaZ", XYZ_SigmaZ[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_GaussSigmaX", XYZ_GaussSigmaX[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_GaussSigmaY", XYZ_GaussSigmaY[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_GaussSigmaZ", XYZ_GaussSigmaZ[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_Length", XYZ_Length[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_Volume", XYZ_Volume[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_MeanX", XYZ_MeanX[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_MeanY", XYZ_MeanY[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_MeanZ", XYZ_MeanZ[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_SkewZ", XYZ_SkewXY[energies1FirstKey]);
+        SetObservableValue("SecondMaxTrack_XYZ_SkewZ", XYZ_SkewZ[energies1FirstKey]);
+
+        Double_t energies1SecondKey = energies[1].second;
+
+        if (fTrackEvent->GetNumberOfTracks() > 2) {
+            SetObservableValue("SecondMaxTrack_XYZ_MaxTrackEnergyPercentage",
+                            (energies1SecondKey) / fTrackEvent->GetEnergy());
+        } else {
+            SetObservableValue("SecondMaxTrack_XYZ_MaxTrackEnergyPercentage", 0.0);
+        }
     } else {
-        SetObservableValue("SecondMaxTrack_XYZ_MaxTrackEnergyPercentage", 0);
+        std::cerr << "Error: energies is empty. Some observables will not be set." << std::endl;
     }
 
     // --- Distance obsevables between first two tracks --- //


### PR DESCRIPTION
![JPorron](https://badgen.net/badge/PR%20submitted%20by%3A/JPorron/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/jporron-Tracks2D-Tracks3D-Issues/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/jporron-Tracks2D-Tracks3D-Issues) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jporron-Tracks2D-Tracks3D-Issues/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jporron-Tracks2D-Tracks3D-Issues) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

There are two different problems:

- Some subruns are not analyzed when using the Tracks2D or Tracks3D analysis. I don´t know why!! It happens in some subruns but not in others. For example, it doesn´t work for "/storage/iaxo/iaxo-lab/data/R02145_Calibration_Vm_325_Vd_900_Pr_1.25_Gain_0x0_Shape_0xF_Clock_0xA-002.aqs" but it does for "/storage/iaxo/iaxo-lab/data/R02145_Calibration_Vm_325_Vd_900_Pr_1.25_Gain_0x0_Shape_0xF_Clock_0xA-001.aqs".

![image](https://github.com/rest-for-physics/tracklib/assets/114648351/5eaf7398-3155-45b3-a840-234a0091ad66)
![image](https://github.com/rest-for-physics/tracklib/assets/114648351/6cc5c03e-b140-409c-b538-2c9536bb063e)

But for the other one:

![image](https://github.com/rest-for-physics/tracklib/assets/114648351/6fc4f9d4-97ed-4272-aa3e-c13a54ea91c2)
![image](https://github.com/rest-for-physics/tracklib/assets/114648351/7522ef52-0a17-4b35-9404-17b2b341354c)


- For some events a TRestReflectorError is shown:

![image](https://github.com/rest-for-physics/tracklib/assets/114648351/47a5a0d3-5757-4c10-a7ca-6de1098e2a74)

It comes in 3, this will be important later.