### PR TITLE
Add sqrt to SigmaZ values since it is calculated with GetSigmaZ2()

### DIFF
--- a/src/TRestTrack2DAnalysisProcess.cxx
+++ b/src/TRestTrack2DAnalysisProcess.cxx
@@ -218,7 +218,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
             XZ_NHitsX[t->GetTrackID()] = t->GetNumberOfHits();
             XZ_EnergyX[t->GetTrackID()] = t->GetTrackEnergy();
             XZ_SigmaX[t->GetTrackID()] = t->GetHits()->GetSigmaX();
-            XZ_SigmaZ[t->GetTrackID()] = t->GetHits()->GetSigmaZ2();
+            XZ_SigmaZ[t->GetTrackID()] = sqrt(t->GetHits()->GetSigmaZ2());
             XZ_GaussSigmaX[t->GetTrackID()] = t->GetHits()->GetGaussSigmaX();
             XZ_GaussSigmaZ[t->GetTrackID()] = t->GetHits()->GetGaussSigmaZ();
             XZ_LengthX[t->GetTrackID()] = t->GetLength();
@@ -254,7 +254,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
             YZ_NHitsY[t->GetTrackID()] = t->GetNumberOfHits();
             YZ_EnergyY[t->GetTrackID()] = t->GetTrackEnergy();
             YZ_SigmaY[t->GetTrackID()] = t->GetHits()->GetSigmaY();
-            YZ_SigmaZ[t->GetTrackID()] = t->GetHits()->GetSigmaZ2();
+            YZ_SigmaZ[t->GetTrackID()] = sqrt(t->GetHits()->GetSigmaZ2());
             YZ_GaussSigmaY[t->GetTrackID()] = t->GetHits()->GetGaussSigmaY();
             YZ_GaussSigmaZ[t->GetTrackID()] = t->GetHits()->GetGaussSigmaZ();
             YZ_LengthY[t->GetTrackID()] = t->GetLength();
@@ -372,7 +372,7 @@ TRestEvent* TRestTrack2DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         }
     }
 
-    MaxTrack_XZ_YZ_SigmaZ = hits.GetSigmaZ2();
+    MaxTrack_XZ_YZ_SigmaZ = sqrt(hits.GetSigmaZ2());
     MaxTrack_XZ_YZ_GaussSigmaZ = hits.GetGaussSigmaZ();
     MaxTrack_XZ_YZ_SkewXY = hits.GetSkewXY();
     MaxTrack_XZ_YZ_SkewZ = hits.GetSkewZ();

--- a/src/TRestTrack3DAnalysisProcess.cxx
+++ b/src/TRestTrack3DAnalysisProcess.cxx
@@ -161,7 +161,7 @@ TRestEvent* TRestTrack3DAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
             XYZ_Energy[t->GetTrackID()] = t->GetTrackEnergy();
             XYZ_SigmaX[t->GetTrackID()] = t->GetHits()->GetSigmaX();
             XYZ_SigmaY[t->GetTrackID()] = t->GetHits()->GetSigmaY();
-            XYZ_SigmaZ[t->GetTrackID()] = t->GetHits()->GetSigmaZ2();
+            XYZ_SigmaZ[t->GetTrackID()] = sqrt(t->GetHits()->GetSigmaZ2());
             XYZ_GaussSigmaX[t->GetTrackID()] = t->GetHits()->GetGaussSigmaX();
             XYZ_GaussSigmaY[t->GetTrackID()] = t->GetHits()->GetGaussSigmaY();
             XYZ_GaussSigmaZ[t->GetTrackID()] = t->GetHits()->GetGaussSigmaZ();


### PR DESCRIPTION
![JPorron](https://badgen.net/badge/PR%20submitted%20by%3A/JPorron/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/jporron-change-observable-name/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/jporron-change-observable-name) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jporron-change-observable-name/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jporron-change-observable-name) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Previously, the XZ_SigmaZ and YZ_SigmaZ observables were being find by simply using GetSigmaZ2(). This GetSigmaZ2() is the squared value of SigmaZ, for example we can see that the GetSigmaX() does the same calculations as GetSigmaZ2() but the applies the squared root. By adding sqrt we find XZ_SigmaZ instead of XZ_SigmaZ2, which is what we were calculating before.

For a given file we see how we get the squared root of 2 of the observables of interest, so instead of sigmaZ2 we get SigmaZ as the observable name indicates:
![image](https://github.com/user-attachments/assets/6b2673ac-95f7-459f-be66-305afbebb03f)
_Fig 1: Before the change we had this values._
![image](https://github.com/user-attachments/assets/7fecf9d2-b9a1-4f4c-b9d4-a059001d62e1)
_Fig 2: After the change._