### PR TITLE
Add fixBoundaries option to linearization process

### DIFF
--- a/inc/TRestTrackLinearizationProcess.h
+++ b/inc/TRestTrackLinearizationProcess.h
@@ -23,9 +23,9 @@
 #ifndef RestCore_TRestTrackLinearizationProcess
 #define RestCore_TRestTrackLinearizationProcess
 
-#include <TRestEventProcess.h>
+#include <TRestTrackEvent.h>
 
-#include "TRestTrackEvent.h"
+#include "TRestEventProcess.h"
 
 //! A process to perform track linearization
 class TRestTrackLinearizationProcess : public TRestEventProcess {
@@ -38,6 +38,7 @@ class TRestTrackLinearizationProcess : public TRestEventProcess {
    protected:
     // A parameter which defines the maximum number of nodes for the track linearization
     Int_t fMaxNodes = 6;
+    Bool_t fFixBoundaries = false;
 
    public:
     RESTValue GetInputEvent() const override { return fTrackEvent; }
@@ -50,6 +51,7 @@ class TRestTrackLinearizationProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
         RESTMetadata << "Max nodes: " << fMaxNodes << RESTendl;
+        RESTMetadata << "Fix boundaries: " << (fFixBoundaries ? "true" : "false") << RESTendl;
         EndPrintProcess();
     }
 
@@ -65,6 +67,6 @@ class TRestTrackLinearizationProcess : public TRestEventProcess {
 
     // ROOT class definition helper. Increase the number in it every time
     // you add/rename/remove the process parameters
-    ClassDefOverride(TRestTrackLinearizationProcess, 1);
+    ClassDefOverride(TRestTrackLinearizationProcess, 2);
 };
 #endif

--- a/src/TRestTrackLinearizationProcess.cxx
+++ b/src/TRestTrackLinearizationProcess.cxx
@@ -36,6 +36,11 @@
 ///
 /// ### Parameters
 /// * fMaxNodes : Maximum number of nodes (hits) to reduce the hits to a line
+/// * fFixBoundaries : Fix the boundaries of the track, i.e. the first and last nodes. It
+/// is recommended to add 2 more nodes to fMaxNodes when setting this parameter to true. This
+/// avoids the first and last nodes being pulled into the center of the track by the
+/// kMeansClustering algorithm. This is useful when you need an accurate measurement of the
+/// track length, but it is less precise (worse length resolution). Default is false.
 ///
 /// ### Examples
 /// \code
@@ -63,7 +68,6 @@
 #include "TRestTrackLinearizationProcess.h"
 
 #include "TRestTrackReductionProcess.h"
-
 using namespace std;
 
 ClassImp(TRestTrackLinearizationProcess);
@@ -167,7 +171,7 @@ void TRestTrackLinearizationProcess::GetHitsProjection(TRestVolumeHits* hits, co
         return;
     }
 
-    TRestVolumeHits::kMeansClustering(hits, vHits, 1);
+    TRestVolumeHits::kMeansClustering(hits, vHits, 1, fFixBoundaries);
 
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
         for (unsigned int i = 0; i < vHits.GetNumberOfHits(); i++)


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 11](https://badgen.net/badge/PR%20Size/Ok%3A%2011/green) [![](https://gitlab.cern.ch/rest-for-physics/tracklib/badges/fixBoundaries/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/tracklib/-/commits/fixBoundaries) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/fixBoundaries/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/fixBoundaries) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When doing the linearization process of tracks for alpha analysis, the length is always a bit shorter than it should. This is due to the kMeansClustering algorithm that tends to pull the nodes position towards the center of the track. This effect is diminuished by adding more nodes, but this ends up messing the track reconstruction and length resolution.

To avoid these, we can fix the position of the first and last node to be at the start and end of the track.

> [!IMPORTANT]
> This change needs first the addition of the fixBoundaries option in `TRestVolumeHits::kMeansClustering`. Approve [PR554](https://github.com/rest-for-physics/framework/pull/554) before this one